### PR TITLE
Use a module relative default path for templates

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -5,7 +5,7 @@ var sander = require('sander');
 var path = require('path');
 var Handlebars = require('handlebars');
 
-var templateDir = 'templates/basic';
+var templateDir = __dirname + '/../templates/basic';
 
 module.exports.setTemplateDir = function(newDir) {
 	templateDir = newDir;


### PR DESCRIPTION
In prosthetic-hand, gobble-leafdoc fails on Windows with NPM 3, since the template path it sets, `node_modules/gobble-leafdoc/node_modules/leafdoc/templates/basic`, does not exist. NPM 3 will flatten `node_modules` so that leafdoc now exists on the same level as gobble-leafdoc.

I think it would be nicer if the default template path would always point to the correct directory, which AFAIK can only be done from inside Leafdoc, by using a path relative to the module instead.
