### PR TITLE
cache templates, refactor inheritability, `optional` documentable flag

### DIFF
--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -569,7 +569,17 @@ Leafdoc.prototype._stringifyNamespace = function(namespace, isMini) {
 	});
 };
 
-
+/*
+ * ðmethod isDocumentableInheritable(name: String): Boolean
+ * Determines documentable can be inherited.
+ */
+Leafdoc.prototype.isDocumentableInheritable = function(name) {
+	return (name === 'method' ||
+		name === 'function' ||
+		name === 'event' ||
+		name === 'option' ||
+		name === 'property');
+};
 
 Leafdoc.prototype._stringifySupersection = function(supersection, ancestors, namespacename, isMini) {
 	var sections = '';
@@ -597,11 +607,7 @@ Leafdoc.prototype._stringifySupersection = function(supersection, ancestors, nam
 	// Calculate inherited documentables.
 	// In the order of the ancestors, check if each documentable has already been
 	// selected for output, skip it if so. Group rest into inherited sections.
-	if (name === 'method' ||
-	    name === 'function' ||
-	    name === 'event' ||
-	    name === 'option' ||
-	    name === 'property') {
+	if (this.isDocumentableInheritable(name)) {
 
 		if (ancestors.length) {
 // 			inheritances += 'Inherits stuff from: ' + inheritances.join(',');

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -274,7 +274,7 @@ Leafdoc.prototype.addStr = function(str, isSource) {
 // 			var match = regex.exec(line);
 
 			while (match = regexps.leafDirective.exec(lineStr)) {
-				// In "ðparam foo, bar", directive is "param" and content is "foo, bar"
+				// In "param foo, bar", directive is "param" and content is "foo, bar"
 // 				console.log('matching directives: ', match);
 				if (match[2]) { match[2] = match[2].trim(); }
 				directives.push([match[1], match[2]]);	// [directive, content]

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -395,7 +395,7 @@ Leafdoc.prototype.addStr = function(str, isSource) {
 
 // 						console.log(content, ', ', alt);
 
-					var name, params = {}, type = null, defaultValue = null;
+					var name, params = {}, type = null, defaultValue = null, optional = false;
 
 					if (content) {
 						var split = regexps.functionDefinition.exec(content);
@@ -403,9 +403,10 @@ Leafdoc.prototype.addStr = function(str, isSource) {
 							console.error('Invalid ' + directive + ' definition: ', content);
 						} else {
 							name = split[1];
-							paramString = split[2];
-							type = split[3];
-							defaultValue = split[4];
+							optional = split[2] == '?';
+							paramString = split[3];
+							type = split[4];
+							defaultValue = split[5];
 
 							if (paramString) {
 								while(match = regexps.functionParam.exec(paramString)) {
@@ -435,6 +436,7 @@ Leafdoc.prototype.addStr = function(str, isSource) {
 							comments: [],
 							params: params,	// Only for functions/methods/factories
 							type: type ? type.trim() : null,
+							optional: optional,
 							defaultValue: defaultValue || null	// Only for options, properties
 						}
 					}

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -114,6 +114,13 @@ Leafdoc.prototype.registerDocumentable = function(name, label) {
 	return this;
 };
 
+// 🍂method getTemplateEngine(): Handlebars
+// Returns handlebars template engine used to render templates.
+// You can use it for override helpers or register new.
+Leafdoc.prototype.getTemplateEngine = function() {
+	return template.engine;
+};
+
 
 // 🍂method setLeadingCharacter(char: String): this
 // In the rare case you don't want to use &#x1f342; as the leading character for
@@ -570,7 +577,7 @@ Leafdoc.prototype._stringifyNamespace = function(namespace, isMini) {
 };
 
 /*
- * ðmethod isDocumentableInheritable(name: String): Boolean
+ * 🍂method isDocumentableInheritable(name: String): Boolean
  * Determines documentable can be inherited.
  */
 Leafdoc.prototype.isDocumentableInheritable = function(name) {

--- a/src/regexps.js
+++ b/src/regexps.js
@@ -47,7 +47,7 @@ var identifier= XRegExp.build('^({{ID_Start}}  ( {{ID_Continue}} | \\. )*)$', {
 // Parses a function name, its return type, and its parameters
 // Funny thing about functions is that not all printable characters are allowed. Thus,
 //   use unicode ID_Start and ID_Continue character sets via 'identifier' sub-regexp.
-var functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) \\s* (?<params> \\( .* \\) ){0,1}   \\s* ( \\: \\s* (?<type> .+? ) )? ( = \\s* (?<default> .+ ) \\s* ){0,1} \$', {
+var functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) (?<required> (\\?{0,1}) ) \\s* (?<params> \\( .* \\) ){0,1}   \\s* ( \\: \\s* (?<type> .+? ) )? ( = \\s* (?<default> .+ ) \\s* ){0,1} \$', {
 	identifier: identifier
 },'nx');
 

--- a/src/template.js
+++ b/src/template.js
@@ -6,7 +6,7 @@ var path = require('path');
 var Handlebars = require('handlebars');
 
 var templateDir = __dirname + '/../templates/basic';
-var templates = {};
+var templates = Object.create(null)
 
 exports.setTemplateDir = function(newDir) {
 	templateDir = newDir;

--- a/src/template.js
+++ b/src/template.js
@@ -6,25 +6,29 @@ var path = require('path');
 var Handlebars = require('handlebars');
 
 var templateDir = __dirname + '/../templates/basic';
+var templates = {};
 
-module.exports.setTemplateDir = function(newDir) {
+exports.setTemplateDir = function(newDir) {
 	templateDir = newDir;
 };
 
-module.exports.getTemplate = function(templateName) {
-	
-	return Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
-	
+exports.getTemplate = function(templateName) {
+	if (!templates[templateName]) {
+		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
+	}
+	return templates[templateName];
 };
 
 
 var _AKAs = {};
 
-module.exports.setAKAs = function(akas){
+exports.setAKAs = function(akas){
 
 // 	console.log('Template thing updating AKAs');
 	_AKAs = akas;
 };
+
+exports.engine = Handlebars;
 
 
 


### PR DESCRIPTION
- let documentables be optional
- added `isDocumentableInheritable` method for ability to add new documentables which could be inheritable
- added `getTemplateEngine` method
- cache compiled templates
