### PR TITLE
Fix broken --character command line switch

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -47,7 +47,7 @@ var argv = minimist( process.argv.slice( 2 ), {
 var doc = new Leafdoc({
 	verbose: argv.verbose,
 	templateDir: argv.template,
-	character: argv.character
+	leadingCharacter: argv.character
 });
 
 argv._.forEach( function(filepath) {


### PR DESCRIPTION
The CLI passes on the value for the `--character` switch as `character` to the `LeafDoc` class, but it should be `leadingCharacter`. This PR fixes this.