### PR TITLE
Refactor comment block regexps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 node_modules
 
+*.actual.json
+*.actual.html

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "module": "src/leafdoc.js",
   "author": "Iván Sánchez Ortega <ivan@sanchezortega.es>",
   "license": "GPL-3.0",
+  "bin": {
+    "leafdoc": "src/cli.js"
+  },
   "dependencies": {
     "handlebars": "^4.0.11",
     "marked": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leafdoc",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A lightweight NaturalDocs-like LeafletJS-style documentation generator",
   "main": "dist/leafdoc.cjs.js",
   "browser": "dist/leafdoc.browser.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "handlebars": "^4.0.11",
-    "marked": "^0.3.5",
+    "marked": "^0.3.12",
     "minimist": "^1.2.0",
     "sander": "^0.6.0",
     "unicode-7.0.0": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "leafdoc",
   "version": "1.4.1",
   "description": "A lightweight NaturalDocs-like LeafletJS-style documentation generator",
-  "main": "src/leafdoc.js",
+  "main": "dist/leafdoc.cjs.js",
+  "browser": "dist/leafdoc.browser.js",
+  "module": "src/leafdoc.js",
   "author": "Iván Sánchez Ortega <ivan@sanchezortega.es>",
-  "license": "GPL",
+  "license": "GPL-3.0",
   "dependencies": {
-    "handlebars": "^3.0.3",
+    "handlebars": "^4.0.11",
     "marked": "^0.3.5",
     "minimist": "^1.2.0",
-    "sander": "^0.3.8",
+    "sander": "^0.6.0",
     "unicode-7.0.0": "^0.1.5",
     "xregexp": "^2.0.0"
   },
@@ -17,13 +19,42 @@
     "update-markdown-leafdoc": "src/cli.js -t templates/markdown src/cli.js src/leafdoc.js --verbose -o Leafdoc.md",
     "update-html-leafdoc": "src/cli.js -t templates/basic src/leafdoc.js src/cli.js --verbose -o Leafdoc.html",
     "prepublish": "npm run update-markdown-leafdoc && npm run update-html-leafdoc",
-    "test": "./test.js"
+    "rollup": "rollup -c rollup.config.js",
+    "test": "rollup -c rollup.config.js; jasmine",
+    "lint": "eslint src/ spec/",
+    "lintfix": "eslint src/ spec/ --fix"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/IvanSanchez/Leafdoc.git"
+    "url": "git://github.com/Leaflet/Leafdoc.git"
   },
-  "bin": {
-    "leafdoc": "src/cli.js"
+  "devDependencies": {
+    "eslint": "^4.16.0",
+    "eslint-config-mourner": "^2.0.3",
+    "eslint-plugin-jasmine": "^2.9.1",
+    "jasmine": "^2.9.0",
+    "rollup": "^0.55.0",
+    "rollup-plugin-buble": "^0.18.0",
+    "rollup-plugin-eslint": "^4.0.0"
+  },
+  "eslintConfig": {
+    "extends": "mourner",
+    "plugins": [
+      "jasmine"
+    ],
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+    },
+    "rules": {
+      "indent": [
+        1,
+        "tab",
+        {
+          "VariableDeclarator": 0,
+          "flatTernaryExpressions": true
+        }
+      ]
+    }
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,70 @@
+
+// import resolve from 'rollup-plugin-node-resolve';
+// import commonjs from 'rollup-plugin-commonjs';
+// import builtins from 'rollup-plugin-node-builtins';
+// import globals from 'rollup-plugin-node-globals';
+import buble from 'rollup-plugin-buble';
+import eslint from 'rollup-plugin-eslint';
+import pkg from './package.json';
+
+export default [
+    // browser-friendly UMD build
+    {
+        input: pkg.module,
+        output: {
+            file: pkg.browser,
+            format: 'iife',
+            sourcemap: true,
+            name: 'leafdoc'
+        },
+        plugins: [
+//             eslint(),
+            buble(),
+//             resolve(), // so Rollup can find `crc32`
+//             commonjs(),
+//             builtins(),
+//             globals()
+        ],
+        external: ['sander', 'path']
+    },
+
+    // CommonJS (for Node) and ES module (for bundlers) build.
+    // (We could have three entries in the configuration array
+    // instead of two, but it's quicker to generate multiple
+    // builds from a single configuration where possible, using
+    // the `targets` option which can specify `dest` and `format`)
+    {
+        input: pkg.module,
+//         external: ['buffer', 'fs', 'jszip', 'debug'],
+        output: [
+            { file: pkg.main, format: 'cjs', sourcemap: true },
+//             { file: pkg.module, format: 'es', sourcemap: true }
+        ],
+        plugins: [
+            eslint(),
+            buble(),
+//             resolve(), // so Rollup can find `crc32`
+// 			commonjs() // so Rollup can convert `crc32` to an ES module
+        ],
+        external: ['sander', 'path']
+    },
+    
+    
+    // Experimental code-splitting build, for exposing all modules (for unit testing)
+    {
+        input: [pkg.module, 'src/parsers/c-like.js', 'src/parsers/trivial.js'],
+        experimentalCodeSplitting: true,
+        experimentalDynamicImport: true,
+        output: {
+            dir: 'dist/split',
+            format: 'cjs'
+        },
+        plugins: [
+            eslint(),
+            buble(),
+//             resolve(), // so Rollup can find `crc32`
+// 			commonjs() // so Rollup can convert `crc32` to an ES module
+        ],
+        external: ['sander', 'path']
+    }
+];

--- a/spec/e2e/basic-math/basic-math.expected.html
+++ b/spec/e2e/basic-math/basic-math.expected.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	<meta charset="utf-8">
+	<style>
+	table {
+		border-collapse: collapse;
+	}
+	table td, table th {
+		border: 1px solid #888;
+	}
+	pre code {
+		display: inline-block;
+		background: #eee;
+	}
+	td:last-child code {
+		background: #eee;
+	}
+	body {
+		font-family: Sans;
+	}
+	</style>
+</head>
+<body>
+	<h2>Leafdoc generated API reference</h2>
+
+	<h2 id='math'>Math</h2>
+
+<h3 id='math-function'>Functions</h3>
+
+<section data-type='[object Object]'>
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='math-rand'>
+		<td><code><b>rand</b>()</nobr></code></td>
+		<td><code>Number</code></td>
+		<td>Returns a random number between 0.0 and 1.0</td>
+	</tr>
+	<tr id='math-log'>
+		<td><code><b>log</b>(<nobr>&lt;Number&gt; <i>x</i></nobr>)</nobr></code></td>
+		<td><code>Number</code></td>
+		<td>Returns the natural logarithm (base e) of the given number</td>
+	</tr>
+</tbody></table>
+</section>
+
+
+
+</body></html>

--- a/spec/e2e/basic-math/basic-math.expected.json
+++ b/spec/e2e/basic-math/basic-math.expected.json
@@ -1,0 +1,58 @@
+{
+ "Math": {
+  "name": "Math",
+  "aka": [],
+  "comments": [],
+  "supersections": {
+   "function": {
+    "name": "function",
+    "aka": [],
+    "comments": [],
+    "sections": {
+     "__default": {
+      "name": "__default",
+      "aka": [],
+      "comments": [],
+      "uninheritable": false,
+      "documentables": {
+       "rand": {
+        "name": "rand",
+        "aka": [],
+        "comments": [
+         "Returns a random number between 0.0 and 1.0"
+        ],
+        "params": {},
+        "type": "Number",
+        "optional": false,
+        "defaultValue": null,
+        "id": "math-rand"
+       },
+       "log": {
+        "name": "log",
+        "aka": [],
+        "comments": [
+         "Returns the natural logarithm (base e) of the given number"
+        ],
+        "params": {
+         "x": {
+          "name": "x",
+          "type": "Number"
+         }
+        },
+        "type": "Number",
+        "optional": false,
+        "defaultValue": null,
+        "id": "math-log"
+       }
+      },
+      "type": "function",
+      "id": "math-function"
+     }
+    },
+    "id": "math-function"
+   }
+  },
+  "inherits": [],
+  "id": "math"
+ }
+}

--- a/spec/e2e/basic-math/math.js
+++ b/spec/e2e/basic-math/math.js
@@ -1,0 +1,12 @@
+// 🍂class Math
+// 🍂function rand(): Number
+// Returns a random number between 0.0 and 1.0
+export function rand(){
+    // Do something here.
+}
+
+// 🍂function log(x: Number): Number
+// Returns the natural logarithm (base e) of the given number
+export function log(x) {
+    // Do something
+}

--- a/spec/e2e/basic-math/math.js
+++ b/spec/e2e/basic-math/math.js
@@ -1,12 +1,12 @@
 // 🍂class Math
 // 🍂function rand(): Number
 // Returns a random number between 0.0 and 1.0
-export function rand(){
-    // Do something here.
+export function rand() {
+	// Do something here.
 }
 
 // 🍂function log(x: Number): Number
 // Returns the natural logarithm (base e) of the given number
 export function log(x) {
-    // Do something
+	// Do something
 }

--- a/spec/e2e/leaflet-domevent/DomEvent.DoubleTap.js
+++ b/spec/e2e/leaflet-domevent/DomEvent.DoubleTap.js
@@ -1,0 +1,86 @@
+import * as Browser from '../core/Browser';
+import {_pointersCount} from './DomEvent.Pointer';
+
+/*
+ * Extends the event handling code with double tap support for mobile browsers.
+ */
+
+var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'pointerdown' : 'touchstart';
+var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
+var _pre = '_leaflet_';
+
+// inspired by Zepto touch code by Thomas Fuchs
+export function addDoubleTapListener(obj, handler, id) {
+	var last, touch,
+	    doubleTap = false,
+	    delay = 250;
+
+	function onTouchStart(e) {
+		var count;
+
+		if (Browser.pointer) {
+			if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+			count = _pointersCount;
+		} else {
+			count = e.touches.length;
+		}
+
+		if (count > 1) { return; }
+
+		var now = Date.now(),
+		    delta = now - (last || now);
+
+		touch = e.touches ? e.touches[0] : e;
+		doubleTap = (delta > 0 && delta <= delay);
+		last = now;
+	}
+
+	function onTouchEnd(e) {
+		if (doubleTap && !touch.cancelBubble) {
+			if (Browser.pointer) {
+				if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+				// work around .type being readonly with MSPointer* events
+				var newTouch = {},
+				    prop, i;
+
+				for (i in touch) {
+					prop = touch[i];
+					newTouch[i] = prop && prop.bind ? prop.bind(touch) : prop;
+				}
+				touch = newTouch;
+			}
+			touch.type = 'dblclick';
+			handler(touch);
+			last = null;
+		}
+	}
+
+	obj[_pre + _touchstart + id] = onTouchStart;
+	obj[_pre + _touchend + id] = onTouchEnd;
+	obj[_pre + 'dblclick' + id] = handler;
+
+	obj.addEventListener(_touchstart, onTouchStart, false);
+	obj.addEventListener(_touchend, onTouchEnd, false);
+
+	// On some platforms (notably, chrome<55 on win10 + touchscreen + mouse),
+	// the browser doesn't fire touchend/pointerup events but does fire
+	// native dblclicks. See #4127.
+	// Edge 14 also fires native dblclicks, but only for pointerType mouse, see #5180.
+	obj.addEventListener('dblclick', handler, false);
+
+	return this;
+}
+
+export function removeDoubleTapListener(obj, id) {
+	var touchstart = obj[_pre + _touchstart + id],
+	    touchend = obj[_pre + _touchend + id],
+	    dblclick = obj[_pre + 'dblclick' + id];
+
+	obj.removeEventListener(_touchstart, touchstart, false);
+	obj.removeEventListener(_touchend, touchend, false);
+	if (!Browser.edge) {
+		obj.removeEventListener('dblclick', dblclick, false);
+	}
+
+	return this;
+}

--- a/spec/e2e/leaflet-domevent/DomEvent.Pointer.js
+++ b/spec/e2e/leaflet-domevent/DomEvent.Pointer.js
@@ -1,0 +1,134 @@
+import * as DomEvent from './DomEvent';
+import * as Util from '../core/Util';
+import * as Browser from '../core/Browser';
+
+/*
+ * Extends L.DomEvent to provide touch support for Internet Explorer and Windows-based devices.
+ */
+
+
+var POINTER_DOWN =   Browser.msPointer ? 'MSPointerDown'   : 'pointerdown';
+var POINTER_MOVE =   Browser.msPointer ? 'MSPointerMove'   : 'pointermove';
+var POINTER_UP =     Browser.msPointer ? 'MSPointerUp'     : 'pointerup';
+var POINTER_CANCEL = Browser.msPointer ? 'MSPointerCancel' : 'pointercancel';
+var TAG_WHITE_LIST = ['INPUT', 'SELECT', 'OPTION'];
+
+var _pointers = {};
+var _pointerDocListener = false;
+
+// DomEvent.DoubleTap needs to know about this
+export var _pointersCount = 0;
+
+// Provides a touch events wrapper for (ms)pointer events.
+// ref http://www.w3.org/TR/pointerevents/ https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
+
+export function addPointerListener(obj, type, handler, id) {
+	if (type === 'touchstart') {
+		_addPointerStart(obj, handler, id);
+
+	} else if (type === 'touchmove') {
+		_addPointerMove(obj, handler, id);
+
+	} else if (type === 'touchend') {
+		_addPointerEnd(obj, handler, id);
+	}
+
+	return this;
+}
+
+export function removePointerListener(obj, type, id) {
+	var handler = obj['_leaflet_' + type + id];
+
+	if (type === 'touchstart') {
+		obj.removeEventListener(POINTER_DOWN, handler, false);
+
+	} else if (type === 'touchmove') {
+		obj.removeEventListener(POINTER_MOVE, handler, false);
+
+	} else if (type === 'touchend') {
+		obj.removeEventListener(POINTER_UP, handler, false);
+		obj.removeEventListener(POINTER_CANCEL, handler, false);
+	}
+
+	return this;
+}
+
+function _addPointerStart(obj, handler, id) {
+	var onDown = Util.bind(function (e) {
+		if (e.pointerType !== 'mouse' && e.MSPOINTER_TYPE_MOUSE && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
+			// In IE11, some touch events needs to fire for form controls, or
+			// the controls will stop working. We keep a whitelist of tag names that
+			// need these events. For other target tags, we prevent default on the event.
+			if (TAG_WHITE_LIST.indexOf(e.target.tagName) < 0) {
+				DomEvent.preventDefault(e);
+			} else {
+				return;
+			}
+		}
+
+		_handlePointer(e, handler);
+	});
+
+	obj['_leaflet_touchstart' + id] = onDown;
+	obj.addEventListener(POINTER_DOWN, onDown, false);
+
+	// need to keep track of what pointers and how many are active to provide e.touches emulation
+	if (!_pointerDocListener) {
+		// we listen documentElement as any drags that end by moving the touch off the screen get fired there
+		document.documentElement.addEventListener(POINTER_DOWN, _globalPointerDown, true);
+		document.documentElement.addEventListener(POINTER_MOVE, _globalPointerMove, true);
+		document.documentElement.addEventListener(POINTER_UP, _globalPointerUp, true);
+		document.documentElement.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
+
+		_pointerDocListener = true;
+	}
+}
+
+function _globalPointerDown(e) {
+	_pointers[e.pointerId] = e;
+	_pointersCount++;
+}
+
+function _globalPointerMove(e) {
+	if (_pointers[e.pointerId]) {
+		_pointers[e.pointerId] = e;
+	}
+}
+
+function _globalPointerUp(e) {
+	delete _pointers[e.pointerId];
+	_pointersCount--;
+}
+
+function _handlePointer(e, handler) {
+	e.touches = [];
+	for (var i in _pointers) {
+		e.touches.push(_pointers[i]);
+	}
+	e.changedTouches = [e];
+
+	handler(e);
+}
+
+function _addPointerMove(obj, handler, id) {
+	var onMove = function (e) {
+		// don't fire touch moves when mouse isn't down
+		if ((e.pointerType === e.MSPOINTER_TYPE_MOUSE || e.pointerType === 'mouse') && e.buttons === 0) { return; }
+
+		_handlePointer(e, handler);
+	};
+
+	obj['_leaflet_touchmove' + id] = onMove;
+	obj.addEventListener(POINTER_MOVE, onMove, false);
+}
+
+function _addPointerEnd(obj, handler, id) {
+	var onUp = function (e) {
+		_handlePointer(e, handler);
+	};
+
+	obj['_leaflet_touchend' + id] = onUp;
+	obj.addEventListener(POINTER_UP, onUp, false);
+	obj.addEventListener(POINTER_CANCEL, onUp, false);
+}
+

--- a/spec/e2e/leaflet-domevent/DomEvent.js
+++ b/spec/e2e/leaflet-domevent/DomEvent.js
@@ -1,0 +1,313 @@
+import {Point} from '../geometry/Point';
+import * as Util from '../core/Util';
+import * as Browser from '../core/Browser';
+import {addPointerListener, removePointerListener} from './DomEvent.Pointer';
+import {addDoubleTapListener, removeDoubleTapListener} from './DomEvent.DoubleTap';
+
+/*
+ * @namespace DomEvent
+ * Utility functions to work with the [DOM events](https://developer.mozilla.org/docs/Web/API/Event), used by Leaflet internally.
+ */
+
+// Inspired by John Resig, Dean Edwards and YUI addEvent implementations.
+
+// @function on(el: HTMLElement, types: String, fn: Function, context?: Object): this
+// Adds a listener function (`fn`) to a particular DOM event type of the
+// element `el`. You can optionally specify the context of the listener
+// (object the `this` keyword will point to). You can also pass several
+// space-separated types (e.g. `'click dblclick'`).
+
+// @alternative
+// @function on(el: HTMLElement, eventMap: Object, context?: Object): this
+// Adds a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
+export function on(obj, types, fn, context) {
+
+	if (typeof types === 'object') {
+		for (var type in types) {
+			addOne(obj, type, types[type], fn);
+		}
+	} else {
+		types = Util.splitWords(types);
+
+		for (var i = 0, len = types.length; i < len; i++) {
+			addOne(obj, types[i], fn, context);
+		}
+	}
+
+	return this;
+}
+
+var eventsKey = '_leaflet_events';
+
+// @function off(el: HTMLElement, types: String, fn: Function, context?: Object): this
+// Removes a previously added listener function.
+// Note that if you passed a custom context to on, you must pass the same
+// context to `off` in order to remove the listener.
+
+// @alternative
+// @function off(el: HTMLElement, eventMap: Object, context?: Object): this
+// Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
+export function off(obj, types, fn, context) {
+
+	if (typeof types === 'object') {
+		for (var type in types) {
+			removeOne(obj, type, types[type], fn);
+		}
+	} else if (types) {
+		types = Util.splitWords(types);
+
+		for (var i = 0, len = types.length; i < len; i++) {
+			removeOne(obj, types[i], fn, context);
+		}
+	} else {
+		for (var j in obj[eventsKey]) {
+			removeOne(obj, j, obj[eventsKey][j]);
+		}
+		delete obj[eventsKey];
+	}
+
+	return this;
+}
+
+function addOne(obj, type, fn, context) {
+	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : '');
+
+	if (obj[eventsKey] && obj[eventsKey][id]) { return this; }
+
+	var handler = function (e) {
+		return fn.call(context || obj, e || window.event);
+	};
+
+	var originalHandler = handler;
+
+	if (Browser.pointer && type.indexOf('touch') === 0) {
+		// Needs DomEvent.Pointer.js
+		addPointerListener(obj, type, handler, id);
+
+	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener &&
+	           !(Browser.pointer && Browser.chrome)) {
+		// Chrome >55 does not need the synthetic dblclicks from addDoubleTapListener
+		// See #5180
+		addDoubleTapListener(obj, handler, id);
+
+	} else if ('addEventListener' in obj) {
+
+		if (type === 'mousewheel') {
+			obj.addEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, false);
+
+		} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+			handler = function (e) {
+				e = e || window.event;
+				if (isExternalTarget(obj, e)) {
+					originalHandler(e);
+				}
+			};
+			obj.addEventListener(type === 'mouseenter' ? 'mouseover' : 'mouseout', handler, false);
+
+		} else {
+			if (type === 'click' && Browser.android) {
+				handler = function (e) {
+					filterClick(e, originalHandler);
+				};
+			}
+			obj.addEventListener(type, handler, false);
+		}
+
+	} else if ('attachEvent' in obj) {
+		obj.attachEvent('on' + type, handler);
+	}
+
+	obj[eventsKey] = obj[eventsKey] || {};
+	obj[eventsKey][id] = handler;
+}
+
+function removeOne(obj, type, fn, context) {
+
+	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : ''),
+	    handler = obj[eventsKey] && obj[eventsKey][id];
+
+	if (!handler) { return this; }
+
+	if (Browser.pointer && type.indexOf('touch') === 0) {
+		removePointerListener(obj, type, id);
+
+	} else if (Browser.touch && (type === 'dblclick') && removeDoubleTapListener &&
+	           !(Browser.pointer && Browser.chrome)) {
+		removeDoubleTapListener(obj, id);
+
+	} else if ('removeEventListener' in obj) {
+
+		if (type === 'mousewheel') {
+			obj.removeEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, false);
+
+		} else {
+			obj.removeEventListener(
+				type === 'mouseenter' ? 'mouseover' :
+				type === 'mouseleave' ? 'mouseout' : type, handler, false);
+		}
+
+	} else if ('detachEvent' in obj) {
+		obj.detachEvent('on' + type, handler);
+	}
+
+	obj[eventsKey][id] = null;
+}
+
+// @function stopPropagation(ev: DOMEvent): this
+// Stop the given event from propagation to parent elements. Used inside the listener functions:
+// ```js
+// L.DomEvent.on(div, 'click', function (ev) {
+// 	L.DomEvent.stopPropagation(ev);
+// });
+// ```
+export function stopPropagation(e) {
+
+	if (e.stopPropagation) {
+		e.stopPropagation();
+	} else if (e.originalEvent) {  // In case of Leaflet event.
+		e.originalEvent._stopped = true;
+	} else {
+		e.cancelBubble = true;
+	}
+	skipped(e);
+
+	return this;
+}
+
+// @function disableScrollPropagation(el: HTMLElement): this
+// Adds `stopPropagation` to the element's `'mousewheel'` events (plus browser variants).
+export function disableScrollPropagation(el) {
+	addOne(el, 'mousewheel', stopPropagation);
+	return this;
+}
+
+// @function disableClickPropagation(el: HTMLElement): this
+// Adds `stopPropagation` to the element's `'click'`, `'doubleclick'`,
+// `'mousedown'` and `'touchstart'` events (plus browser variants).
+export function disableClickPropagation(el) {
+	on(el, 'mousedown touchstart dblclick', stopPropagation);
+	addOne(el, 'click', fakeStop);
+	return this;
+}
+
+// @function preventDefault(ev: DOMEvent): this
+// Prevents the default action of the DOM Event `ev` from happening (such as
+// following a link in the href of the a element, or doing a POST request
+// with page reload when a `<form>` is submitted).
+// Use it inside listener functions.
+export function preventDefault(e) {
+	if (e.preventDefault) {
+		e.preventDefault();
+	} else {
+		e.returnValue = false;
+	}
+	return this;
+}
+
+// @function stop(ev: DOMEvent): this
+// Does `stopPropagation` and `preventDefault` at the same time.
+export function stop(e) {
+	preventDefault(e);
+	stopPropagation(e);
+	return this;
+}
+
+// @function getMousePosition(ev: DOMEvent, container?: HTMLElement): Point
+// Gets normalized mouse position from a DOM event relative to the
+// `container` or to the whole page if not specified.
+export function getMousePosition(e, container) {
+	if (!container) {
+		return new Point(e.clientX, e.clientY);
+	}
+
+	var rect = container.getBoundingClientRect();
+
+	var scaleX = rect.width / container.offsetWidth || 1;
+	var scaleY = rect.height / container.offsetHeight || 1;
+	return new Point(
+		e.clientX / scaleX - rect.left - container.clientLeft,
+		e.clientY / scaleY - rect.top - container.clientTop);
+}
+
+// Chrome on Win scrolls double the pixels as in other platforms (see #4538),
+// and Firefox scrolls device pixels, not CSS pixels
+var wheelPxFactor =
+	(Browser.win && Browser.chrome) ? 2 * window.devicePixelRatio :
+	Browser.gecko ? window.devicePixelRatio : 1;
+
+// @function getWheelDelta(ev: DOMEvent): Number
+// Gets normalized wheel delta from a mousewheel DOM event, in vertical
+// pixels scrolled (negative if scrolling down).
+// Events from pointing devices without precise scrolling are mapped to
+// a best guess of 60 pixels.
+export function getWheelDelta(e) {
+	return (Browser.edge) ? e.wheelDeltaY / 2 : // Don't trust window-geometry-based delta
+	       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / wheelPxFactor : // Pixels
+	       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 20 : // Lines
+	       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 60 : // Pages
+	       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events
+	       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
+	       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 20 : // Legacy Moz lines
+	       e.detail ? e.detail / -32765 * 60 : // Legacy Moz pages
+	       0;
+}
+
+var skipEvents = {};
+
+export function fakeStop(e) {
+	// fakes stopPropagation by setting a special event flag, checked/reset with skipped(e)
+	skipEvents[e.type] = true;
+}
+
+export function skipped(e) {
+	var events = skipEvents[e.type];
+	// reset when checking, as it's only used in map container and propagates outside of the map
+	skipEvents[e.type] = false;
+	return events;
+}
+
+// check if element really left/entered the event target (for mouseenter/mouseleave)
+export function isExternalTarget(el, e) {
+
+	var related = e.relatedTarget;
+
+	if (!related) { return true; }
+
+	try {
+		while (related && (related !== el)) {
+			related = related.parentNode;
+		}
+	} catch (err) {
+		return false;
+	}
+	return (related !== el);
+}
+
+var lastClick;
+
+// this is a horrible workaround for a bug in Android where a single touch triggers two click events
+function filterClick(e, handler) {
+	var timeStamp = (e.timeStamp || (e.originalEvent && e.originalEvent.timeStamp)),
+	    elapsed = lastClick && (timeStamp - lastClick);
+
+	// are they closer together than 500ms yet more than 100ms?
+	// Android typically triggers them ~300ms apart while multiple listeners
+	// on the same event should be triggered far faster;
+	// or check if click is simulated on the element, and if it is, reject any non-simulated events
+
+	if ((elapsed && elapsed > 100 && elapsed < 500) || (e.target._simulatedClick && !e._simulated)) {
+		stop(e);
+		return;
+	}
+	lastClick = timeStamp;
+
+	handler(e);
+}
+
+// @function addListener(…): this
+// Alias to [`L.DomEvent.on`](#domevent-on)
+export {on as addListener};
+
+// @function removeListener(…): this
+// Alias to [`L.DomEvent.off`](#domevent-off)
+export {off as removeListener};

--- a/spec/e2e/leaflet-domevent/leafdoc-options.json
+++ b/spec/e2e/leaflet-domevent/leafdoc-options.json
@@ -1,0 +1,5 @@
+{
+    "templateDir": "./templates/leaflet",
+    "showInheritancesWhenEmpty": true,
+    "leadingCharacter": "@"
+}

--- a/spec/e2e/leaflet-domevent/leaflet-domevent.expected.html
+++ b/spec/e2e/leaflet-domevent/leaflet-domevent.expected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>{{ title }}</title>
+	<title></title>
 	<meta charset="utf-8">
 
 	<link rel="stylesheet" href="http://leafletjs.com/docs/css/normalize.css" />
@@ -137,7 +137,111 @@
 		</div>
 	</div>
 
-	{{{ body }}}
+	<h2 id='domevent'>DomEvent</h2><p>Utility functions to work with the <a href="https://developer.mozilla.org/docs/Web/API/Event">DOM events</a>, used by Leaflet internally.</p>
+
+<section>
+<h3 id='domevent-function'>Functions</h3>
+
+<section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='domevent-on'>
+		<td><code><b>on</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;String&gt;</nobr> <i>types</i>, <nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Adds a listener function (<code>fn</code>) to a particular DOM event type of the
+element <code>el</code>. You can optionally specify the context of the listener
+(object the <code>this</code> keyword will point to). You can also pass several
+space-separated types (e.g. <code>&#39;click dblclick&#39;</code>).</td>
+	</tr>
+	<tr id='domevent-on'>
+		<td><code><b>on</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;Object&gt;</nobr> <i>eventMap</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Adds a set of type/listener pairs, e.g. <code>{click: onClick, mousemove: onMouseMove}</code></td>
+	</tr>
+	<tr id='domevent-off'>
+		<td><code><b>off</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;String&gt;</nobr> <i>types</i>, <nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Removes a previously added listener function.
+Note that if you passed a custom context to on, you must pass the same
+context to <code>off</code> in order to remove the listener.</td>
+	</tr>
+	<tr id='domevent-off'>
+		<td><code><b>off</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;Object&gt;</nobr> <i>eventMap</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Removes a set of type/listener pairs, e.g. <code>{click: onClick, mousemove: onMouseMove}</code></td>
+	</tr>
+	<tr id='domevent-stoppropagation'>
+		<td><code><b>stopPropagation</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Stop the given event from propagation to parent elements. Used inside the listener functions:
+<pre><code class="lang-js">L.DomEvent.on(div, &#39;click&#39;, function (ev) {
+    L.DomEvent.stopPropagation(ev);
+});
+</code></pre></td>
+	</tr>
+	<tr id='domevent-disablescrollpropagation'>
+		<td><code><b>disableScrollPropagation</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Adds <code>stopPropagation</code> to the element&#39;s <code>&#39;mousewheel&#39;</code> events (plus browser variants).</td>
+	</tr>
+	<tr id='domevent-disableclickpropagation'>
+		<td><code><b>disableClickPropagation</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Adds <code>stopPropagation</code> to the element&#39;s <code>&#39;click&#39;</code>, <code>&#39;doubleclick&#39;</code>,
+<code>&#39;mousedown&#39;</code> and <code>&#39;touchstart&#39;</code> events (plus browser variants).</td>
+	</tr>
+	<tr id='domevent-preventdefault'>
+		<td><code><b>preventDefault</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Prevents the default action of the DOM Event <code>ev</code> from happening (such as
+following a link in the href of the a element, or doing a POST request
+with page reload when a <code>&lt;form&gt;</code> is submitted).
+Use it inside listener functions.</td>
+	</tr>
+	<tr id='domevent-stop'>
+		<td><code><b>stop</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Does <code>stopPropagation</code> and <code>preventDefault</code> at the same time.</td>
+	</tr>
+	<tr id='domevent-getmouseposition'>
+		<td><code><b>getMousePosition</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>, <nobr>&lt;HTMLElement&gt;</nobr> <i>container?</i>)</nobr></code></td>
+		<td><code>Point</code></td>
+		<td>Gets normalized mouse position from a DOM event relative to the
+<code>container</code> or to the whole page if not specified.</td>
+	</tr>
+	<tr id='domevent-getwheeldelta'>
+		<td><code><b>getWheelDelta</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>)</nobr></code></td>
+		<td><code>Number</code></td>
+		<td>Gets normalized wheel delta from a mousewheel DOM event, in vertical
+pixels scrolled (negative if scrolling down).
+Events from pointing devices without precise scrolling are mapped to
+a best guess of 60 pixels.</td>
+	</tr>
+	<tr id='domevent-addlistener'>
+		<td><code><b>addListener</b>(<i>…</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Alias to <a href="#domevent-on"><code>L.DomEvent.on</code></a></td>
+	</tr>
+	<tr id='domevent-removelistener'>
+		<td><code><b>removeListener</b>(<i>…</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Alias to <a href="#domevent-off"><code>L.DomEvent.off</code></a></td>
+	</tr>
+</tbody></table>
+
+</section>
+
+
+</section>
 
 
 

--- a/spec/e2e/leaflet-domevent/leaflet-domevent.expected.json
+++ b/spec/e2e/leaflet-domevent/leaflet-domevent.expected.json
@@ -1,0 +1,312 @@
+{
+ "DomEvent": {
+  "name": "DomEvent",
+  "aka": [],
+  "comments": [
+   "Utility functions to work with the [DOM events](https://developer.mozilla.org/docs/Web/API/Event), used by Leaflet internally."
+  ],
+  "supersections": {
+   "function": {
+    "name": "function",
+    "aka": [],
+    "comments": [],
+    "sections": {
+     "__default": {
+      "name": "__default",
+      "aka": [],
+      "comments": [],
+      "uninheritable": false,
+      "documentables": {
+       "on": {
+        "name": "on",
+        "aka": [],
+        "comments": [
+         "Adds a listener function (`fn`) to a particular DOM event type of the",
+         "element `el`. You can optionally specify the context of the listener",
+         "(object the `this` keyword will point to). You can also pass several",
+         "space-separated types (e.g. `'click dblclick'`)."
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         },
+         "types": {
+          "name": "types",
+          "type": "String"
+         },
+         "fn": {
+          "name": "fn",
+          "type": "Function"
+         },
+         "context?": {
+          "name": "context?",
+          "type": "Object"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-on"
+       },
+       "on-alternative-1": {
+        "name": "on",
+        "aka": [],
+        "comments": [
+         "Adds a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`"
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         },
+         "eventMap": {
+          "name": "eventMap",
+          "type": "Object"
+         },
+         "context?": {
+          "name": "context?",
+          "type": "Object"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-on"
+       },
+       "off": {
+        "name": "off",
+        "aka": [],
+        "comments": [
+         "Removes a previously added listener function.",
+         "Note that if you passed a custom context to on, you must pass the same",
+         "context to `off` in order to remove the listener."
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         },
+         "types": {
+          "name": "types",
+          "type": "String"
+         },
+         "fn": {
+          "name": "fn",
+          "type": "Function"
+         },
+         "context?": {
+          "name": "context?",
+          "type": "Object"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-off"
+       },
+       "off-alternative-1": {
+        "name": "off",
+        "aka": [],
+        "comments": [
+         "Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`"
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         },
+         "eventMap": {
+          "name": "eventMap",
+          "type": "Object"
+         },
+         "context?": {
+          "name": "context?",
+          "type": "Object"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-off"
+       },
+       "stopPropagation": {
+        "name": "stopPropagation",
+        "aka": [],
+        "comments": [
+         "Stop the given event from propagation to parent elements. Used inside the listener functions:",
+         "```js",
+         "L.DomEvent.on(div, 'click', function (ev) {",
+         "\tL.DomEvent.stopPropagation(ev);",
+         "});",
+         "```"
+        ],
+        "params": {
+         "ev": {
+          "name": "ev",
+          "type": "DOMEvent"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-stoppropagation"
+       },
+       "disableScrollPropagation": {
+        "name": "disableScrollPropagation",
+        "aka": [],
+        "comments": [
+         "Adds `stopPropagation` to the element's `'mousewheel'` events (plus browser variants)."
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-disablescrollpropagation"
+       },
+       "disableClickPropagation": {
+        "name": "disableClickPropagation",
+        "aka": [],
+        "comments": [
+         "Adds `stopPropagation` to the element's `'click'`, `'doubleclick'`,",
+         "`'mousedown'` and `'touchstart'` events (plus browser variants)."
+        ],
+        "params": {
+         "el": {
+          "name": "el",
+          "type": "HTMLElement"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-disableclickpropagation"
+       },
+       "preventDefault": {
+        "name": "preventDefault",
+        "aka": [],
+        "comments": [
+         "Prevents the default action of the DOM Event `ev` from happening (such as",
+         "following a link in the href of the a element, or doing a POST request",
+         "with page reload when a `<form>` is submitted).",
+         "Use it inside listener functions."
+        ],
+        "params": {
+         "ev": {
+          "name": "ev",
+          "type": "DOMEvent"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-preventdefault"
+       },
+       "stop": {
+        "name": "stop",
+        "aka": [],
+        "comments": [
+         "Does `stopPropagation` and `preventDefault` at the same time."
+        ],
+        "params": {
+         "ev": {
+          "name": "ev",
+          "type": "DOMEvent"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-stop"
+       },
+       "getMousePosition": {
+        "name": "getMousePosition",
+        "aka": [],
+        "comments": [
+         "Gets normalized mouse position from a DOM event relative to the",
+         "`container` or to the whole page if not specified."
+        ],
+        "params": {
+         "ev": {
+          "name": "ev",
+          "type": "DOMEvent"
+         },
+         "container?": {
+          "name": "container?",
+          "type": "HTMLElement"
+         }
+        },
+        "type": "Point",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-getmouseposition"
+       },
+       "getWheelDelta": {
+        "name": "getWheelDelta",
+        "aka": [],
+        "comments": [
+         "Gets normalized wheel delta from a mousewheel DOM event, in vertical",
+         "pixels scrolled (negative if scrolling down).",
+         "Events from pointing devices without precise scrolling are mapped to",
+         "a best guess of 60 pixels."
+        ],
+        "params": {
+         "ev": {
+          "name": "ev",
+          "type": "DOMEvent"
+         }
+        },
+        "type": "Number",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-getwheeldelta"
+       },
+       "addListener": {
+        "name": "addListener",
+        "aka": [],
+        "comments": [
+         "Alias to [`L.DomEvent.on`](#domevent-on)"
+        ],
+        "params": {
+         "…": {
+          "name": "…"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-addlistener"
+       },
+       "removeListener": {
+        "name": "removeListener",
+        "aka": [],
+        "comments": [
+         "Alias to [`L.DomEvent.off`](#domevent-off)"
+        ],
+        "params": {
+         "…": {
+          "name": "…"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "domevent-removelistener"
+       }
+      },
+      "type": "function",
+      "id": "domevent-function"
+     }
+    },
+    "id": "domevent-function"
+   }
+  },
+  "inherits": [],
+  "id": "domevent"
+ }
+}

--- a/spec/e2e/leaflet-domevent/leaflet-domevent.expected.json
+++ b/spec/e2e/leaflet-domevent/leaflet-domevent.expected.json
@@ -3,7 +3,8 @@
   "name": "DomEvent",
   "aka": [],
   "comments": [
-   "Utility functions to work with the [DOM events](https://developer.mozilla.org/docs/Web/API/Event), used by Leaflet internally."
+   "Utility functions to work with the [DOM events](https://developer.mozilla.org/docs/Web/API/Event), used by Leaflet internally.",
+   ""
   ],
   "supersections": {
    "function": {

--- a/spec/e2e/leaflet-map-eachlayer/Layer.js
+++ b/spec/e2e/leaflet-map-eachlayer/Layer.js
@@ -1,0 +1,29 @@
+
+
+/* @namespace Map
+ *
+ * @section Methods for Layers and Controls
+ */
+Map.include({
+
+	// @method hasLayer(layer: Layer): Boolean
+	// Returns `true` if the given layer is currently added to the map
+	hasLayer: function (layer) {
+		return !!layer && (Util.stamp(layer) in this._layers);
+	},
+
+	/* @method eachLayer(fn: Function, context?: Object): this
+	 * Iterates over the layers of the map, optionally specifying context of the iterator function.
+	 * ```
+	 * map.eachLayer(function(layer){
+	 *     layer.bindPopup('Hello');
+	 * });
+	 * ```
+	 */
+	eachLayer: function (method, context) {
+		for (var i in this._layers) {
+			method.call(context, this._layers[i]);
+		}
+		return this;
+	},
+});

--- a/spec/e2e/leaflet-map-eachlayer/leafdoc-options.json
+++ b/spec/e2e/leaflet-map-eachlayer/leafdoc-options.json
@@ -1,0 +1,5 @@
+{
+    "templateDir": "./templates/leaflet",
+    "showInheritancesWhenEmpty": true,
+    "leadingCharacter": "@"
+}

--- a/spec/e2e/leaflet-map-eachlayer/leaflet-map-eachlayer.expected.html
+++ b/spec/e2e/leaflet-map-eachlayer/leaflet-map-eachlayer.expected.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	<meta charset="utf-8">
+
+	<link rel="stylesheet" href="http://leafletjs.com/docs/css/normalize.css" />
+	<link rel="stylesheet" href="http://leafletjs.com/docs/css/main.css" />
+	<script src="http://leafletjs.com/docs/highlight/highlight.pack.js"></script>
+	<link rel="stylesheet" href="http://leafletjs.com/docs/highlight/styles/github-gist.css" />
+	<link rel="stylesheet" href="http://leafletjs.com/dist/leaflet.css" />
+	<script src="http://leafletjs.com/dist/leaflet.js"></script>
+</head>
+<body class='api-page'>
+	<div class='container'>
+
+	<h2>Leaflet API reference</h2>
+	<div id="toc" class="clearfix">
+		<div class="toc-col map-col">
+			<h4>Map</h4>
+			<ul>
+				<li><a href="#map-example">Usage example</a></li>
+				<li><a href="#map-factory">Creation</a></li>
+				<li><a href="#map-option">Options</a></li>
+				<li><a href="#map-event">Events</a></li>
+			</ul>
+			<h4>Map Methods</h4>
+			<ul>
+				<li><a href="#map-methods-for-modifying-map-state">Modifying map state</a></li>
+				<li><a href="#map-methods-for-getting-map-state">Getting map state</a></li>
+				<li><a href="#map-methods-for-layers-and-controls">Layers and controls</a></li>
+				<li><a href="#map-conversion-methods">Conversion methods</a></li>
+				<li><a href="#map-other-methods">Other methods</a></li>
+			</ul>
+			<h4>Map Misc</h4>
+			<ul>
+				<li><a href="#map-property">Properties</a></li>
+				<li><a href="#map-pane">Panes</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+			<h4>UI Layers</h4>
+			<ul>
+				<li><a href="#marker">Marker</a></li>
+				<li><a href="#popup">Popup</a></li>
+				<li><a href="#tooltip">Tooltip</a></li>
+			</ul>
+			<h4>Raster Layers</h4>
+			<ul>
+				<li><a href="#tilelayer">TileLayer</a></li>
+				<li><a href="#tilelayer-wms">TileLayer.WMS</a></li>
+				<li><a href="#imageoverlay">ImageOverlay</a></li>
+				<li><a href="#videooverlay">VideoOverlay</a></li>
+			</ul>
+			<h4>Vector Layers</h4>
+			<ul>
+				<li><a href="#path">Path</a></li>
+				<li><a href="#polyline">Polyline</a></li>
+				<li><a href="#polygon">Polygon</a></li>
+				<li><a href="#rectangle">Rectangle</a></li>
+				<li><a href="#circle">Circle</a></li>
+				<li><a href="#circlemarker">CircleMarker</a></li>
+				<li><a href="#svg">SVG</a></li>
+				<li><a href="#canvas">Canvas</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+			<h4>Other Layers</h4>
+			<ul>
+				<li><a href="#layergroup">LayerGroup</a></li>
+				<li><a href="#featuregroup">FeatureGroup</a></li>
+				<li><a href="#geojson">GeoJSON</a></li>
+				<li><a href="#gridlayer">GridLayer</a></li>
+			</ul>
+			<h4>Basic Types</h4>
+			<ul>
+				<li><a href="#latlng">LatLng</a></li>
+				<li><a href="#latlngbounds">LatLngBounds</a></li>
+				<li><a href="#point">Point</a></li>
+				<li><a href="#bounds">Bounds</a></li>
+				<li><a href="#icon">Icon</a></li>
+				<li><a href="#divicon">DivIcon</a></li>
+			</ul>
+			<h4>Controls</h4>
+			<ul>
+				<li><a href="#control-zoom">Zoom</a></li>
+				<li><a href="#control-attribution">Attribution</a></li>
+				<li><a href="#control-layers">Layers</a></li>
+				<li><a href="#control-scale">Scale</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+<!-- 			<h4>Shared Methods</h4> -->
+<!-- 			<ul> -->
+<!-- 				<li><a href="#evented">Event</a></li> -->
+<!-- 				<li><a href="#layers">Layer</a></li> -->
+<!-- 				<li><a href="#popup">Popup</a></li> -->
+<!-- 			</ul> -->
+			<h4>Utility</h4>
+			<ul>
+				<li><a href="#browser">Browser</a></li>
+				<li><a href="#util">Util</a></li>
+				<li><a href="#transformation">Transformation</a></li>
+				<li><a href="#lineutil">LineUtil</a></li>
+				<li><a href="#polyutil">PolyUtil</a></li>
+			</ul>
+			<h4>DOM Utility</h4>
+			<ul>
+				<li><a href="#domevent">DomEvent</a></li>
+				<li><a href="#domutil">DomUtil</a></li>
+				<li><a href="#posanimation">PosAnimation</a></li>
+				<li><a href="#draggable">Draggable</a></li>
+			</ul>
+		</div>
+		<div class="toc-col last-col">
+			<h4>Base Classes</h4>
+			<ul>
+				<li><a href="#class">Class</a></li>
+				<li><a href="#evented">Evented</a></li>
+				<li><a href="#layer">Layer</a></li>
+				<li><a href="#interactive-layer">Interactive layer</a></li>
+				<li><a href="#control">Control</a></li>
+				<li><a href="#handler">Handler</a></li>
+				<!--<li><a class="nodocs" href="#">IFeature</a></li>-->
+				<li><a href="#projection">Projection</a></li>
+				<li><a href="#crs">CRS</a></li>
+				<li><a href="#renderer">Renderer</a></li>
+			</ul>
+
+			<h4>Misc</h4>
+			<ul>
+				<li><a href="#event-objects">Event objects</a></li>
+ 				<li><a href="#global-switches">global switches</a></li>
+				<li><a href="#noconflict">noConflict</a></li>
+				<li><a href="#version">version</a></li>
+			</ul>
+		</div>
+	</div>
+
+	<h2 id='map'>Map</h2>
+<section>
+<h3 id='map-method'>Methods</h3>
+
+<section class='collapsable'>
+
+<h4 id='map-methods-for-layers-and-controls'>Methods for Layers and Controls</h4>
+
+<div class='section-comments'></div>
+
+<table><thead>
+	<tr>
+		<th>Method</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='map-haslayer'>
+		<td><code><b>hasLayer</b>(<nobr>&lt;Layer&gt;</nobr> <i>layer</i>)</nobr></code></td>
+		<td><code>Boolean</code></td>
+		<td><p>Returns <code>true</code> if the given layer is currently added to the map</p>
+</td>
+	</tr>
+	<tr id='map-eachlayer'>
+		<td><code><b>eachLayer</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</nobr></code></td>
+		<td><code>this</code></td>
+		<td><p>Iterates over the layers of the map, optionally specifying context of the iterator function.</p>
+<pre><code>map.eachLayer(function(layer){
+    layer.bindPopup(&#39;Hello&#39;);
+});
+</code></pre></td>
+	</tr>
+</tbody></table>
+
+</section>
+
+
+</section>
+
+
+
+	<div class="footer">
+		<p>© 2017 <a href="http://agafonkin.com/en">Vladimir Agafonkin</a>. Maps © <a 	href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors.</p>
+	</div>
+
+	</div>
+
+	<script src="http://leafletjs.com/docs/js/docs.js"></script>
+	<script>
+	hljs.configure({tabReplace: '    '});
+	hljs.initHighlightingOnLoad();
+
+	var elems = document.querySelectorAll('h2, h3, h4, tr');
+
+	for (var i = 0, len = elems.length; i < len; i++) {
+		var el = elems[i];
+
+		if (el.id) {
+			var anchor = document.createElement('a');
+			anchor.setAttribute('anchor', el.id);
+			if (!el.children.length) {
+				// For headers, insert the anchor before.
+				el.parentNode.insertBefore(anchor, el);
+			} else {
+				// For table rows, insert the anchor inside the first <td>
+				el.querySelector('td').appendChild(anchor);
+
+				// Clicking on the row (meaning "the link icon on the ::before)
+				// jumps to the item
+				el.parentNode.onclick = function(hash){
+					return function(ev) {
+						if (ev.offsetX < 0) {
+							window.location.hash = '#' + ev.target.parentNode.id;
+						}
+					};
+				}(el.id);
+			}
+		}
+	}
+
+	elems = document.querySelectorAll('div.accordion');
+	for (var i = 0, len = elems.length; i < len; i++) {
+		var el = elems[i];
+
+		el.querySelector('label').addEventListener('click', function(c){
+			return function() {
+				if (c.className === 'accordion expanded') {
+					c.className = 'accordion collapsed';
+				} else {
+					c.className = 'accordion expanded';
+				}
+			};
+		}(el));
+
+// 		el.className = 'accordion collapsed';
+// 		el.querySelector('.accordion-content').style.display = 'none';
+	}
+
+</script>
+<style>
+
+	h2 {
+		margin-top: 2em;
+	}
+
+	h3 {
+		margin-top: 1em;
+		margin-bottom: .5em;
+	}
+
+	div.accordion {
+		width: 100%;
+/* 		overflow: hidden; */
+	}
+
+	div.accordion-overflow {
+		width: 100%;
+		overflow: hidden;
+	}
+
+	label,
+	section > h4 {
+		display: block;
+		font-weight: 500;
+		margin: 1em 0 0.25em;
+	}
+
+	label {
+		cursor: pointer;
+	}
+
+	div.accordion > div.accordion-overflow > div.accordion-content {
+		max-height: 0;
+		display: none;
+	}
+
+	div.accordion.collapsed > div.accordion-overflow > div.accordion-content {
+		animation-duration: 0.4s;
+		animation-name: collapse;
+/* 		height: 0; */
+		max-height: 0;
+		display: block;
+		overflow: hidden;
+	}
+
+	div.accordion.expanded > div.accordion-overflow > div.accordion-content {
+		animation-duration: 0.4s;
+		animation-name: expand;
+/* 		height: auto; */
+		max-height: none;
+		display: block;
+	}
+
+	@keyframes collapse {
+		0% { max-height: 100vh; }
+		100% { max-height: 0; }
+	}
+
+	@keyframes expand {
+		0% { max-height: 0; }
+		100% { max-height: 100vh; }
+	}
+
+/*	div.accordion > div.accordion-content {
+		transition: max-height 0.4s ease-out 0s;
+	}*/
+
+	div.accordion.expanded > label > span.expander {
+		transform: rotate(90deg);
+	}
+
+	div.accordion > label > span.expander {
+		transition: transform 0.4s ease-out 0s;
+		display: inline-block;
+		font-size: 12px;
+	}
+
+
+	table {
+		margin-bottom: 0;
+	}
+
+/* 	Markdown renders some spurious <p>s inside the table cells */
+	td > p {
+		margin:0;
+	}
+
+/* 	This just looks bad (with the current grey headers for sections which Vlad doesn't really like, so might have to change this) */
+	section.collapsable > div.section-comments > p {
+		margin:0;
+	}
+
+	div.section-comments {
+		margin-bottom: 0.25em;
+	}
+
+/*	section.collapsable div.section-comments {
+		margin: 1em;
+		font-size: 12px;
+	}*/
+
+	section.collapsable pre {
+		margin:0;
+	}
+
+	section {
+		margin-left: 0.5em;
+	}
+
+	section h4, section.collapsable h4 {
+		margin-left: -0.5em;
+	}
+
+
+
+</style>
+</body></html>

--- a/spec/e2e/leaflet-map-eachlayer/leaflet-map-eachlayer.expected.json
+++ b/spec/e2e/leaflet-map-eachlayer/leaflet-map-eachlayer.expected.json
@@ -1,0 +1,77 @@
+{
+ "Map": {
+  "name": "Map",
+  "aka": [],
+  "comments": [
+   ""
+  ],
+  "supersections": {
+   "method": {
+    "name": "method",
+    "aka": [],
+    "comments": [],
+    "sections": {
+     "Methods for Layers and Controls": {
+      "name": "Methods for Layers and Controls",
+      "aka": [],
+      "comments": [
+       ""
+      ],
+      "uninheritable": false,
+      "documentables": {
+       "hasLayer": {
+        "name": "hasLayer",
+        "aka": [],
+        "comments": [
+         "Returns `true` if the given layer is currently added to the map"
+        ],
+        "params": {
+         "layer": {
+          "name": "layer",
+          "type": "Layer"
+         }
+        },
+        "type": "Boolean",
+        "optional": false,
+        "defaultValue": null,
+        "id": "map-haslayer"
+       },
+       "eachLayer": {
+        "name": "eachLayer",
+        "aka": [],
+        "comments": [
+         "Iterates over the layers of the map, optionally specifying context of the iterator function.",
+         "```",
+         "map.eachLayer(function(layer){",
+         "    layer.bindPopup('Hello');",
+         "});",
+         "```",
+         ""
+        ],
+        "params": {
+         "fn": {
+          "name": "fn",
+          "type": "Function"
+         },
+         "context?": {
+          "name": "context?",
+          "type": "Object"
+         }
+        },
+        "type": "this",
+        "optional": false,
+        "defaultValue": null,
+        "id": "map-eachlayer"
+       }
+      },
+      "type": "method",
+      "id": "map-methods-for-layers-and-controls"
+     }
+    },
+    "id": "map-method"
+   }
+  },
+  "inherits": [],
+  "id": "map"
+ }
+}

--- a/spec/e2e/leaflet-vml/SVG.VML.js
+++ b/spec/e2e/leaflet-vml/SVG.VML.js
@@ -1,0 +1,143 @@
+import * as DomUtil from '../../dom/DomUtil';
+import * as Util from '../../core/Util';
+import {Renderer} from './Renderer';
+
+/*
+ * Thanks to Dmitry Baranovsky and his Raphael library for inspiration!
+ */
+
+
+export var vmlCreate = (function () {
+	try {
+		document.namespaces.add('lvml', 'urn:schemas-microsoft-com:vml');
+		return function (name) {
+			return document.createElement('<lvml:' + name + ' class="lvml">');
+		};
+	} catch (e) {
+		return function (name) {
+			return document.createElement('<' + name + ' xmlns="urn:schemas-microsoft.com:vml" class="lvml">');
+		};
+	}
+})();
+
+
+/*
+ * @class SVG
+ *
+ * Although SVG is not available on IE7 and IE8, these browsers support [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language), and the SVG renderer will fall back to VML in this case.
+ *
+ * VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
+ * with old versions of Internet Explorer.
+ */
+
+// mixin to redefine some SVG methods to handle VML syntax which is similar but with some differences
+export var vmlMixin = {
+
+	_initContainer: function () {
+		this._container = DomUtil.create('div', 'leaflet-vml-container');
+	},
+
+	_update: function () {
+		if (this._map._animatingZoom) { return; }
+		Renderer.prototype._update.call(this);
+		this.fire('update');
+	},
+
+	_initPath: function (layer) {
+		var container = layer._container = vmlCreate('shape');
+
+		DomUtil.addClass(container, 'leaflet-vml-shape ' + (this.options.className || ''));
+
+		container.coordsize = '1 1';
+
+		layer._path = vmlCreate('path');
+		container.appendChild(layer._path);
+
+		this._updateStyle(layer);
+		this._layers[Util.stamp(layer)] = layer;
+	},
+
+	_addPath: function (layer) {
+		var container = layer._container;
+		this._container.appendChild(container);
+
+		if (layer.options.interactive) {
+			layer.addInteractiveTarget(container);
+		}
+	},
+
+	_removePath: function (layer) {
+		var container = layer._container;
+		DomUtil.remove(container);
+		layer.removeInteractiveTarget(container);
+		delete this._layers[Util.stamp(layer)];
+	},
+
+	_updateStyle: function (layer) {
+		var stroke = layer._stroke,
+		    fill = layer._fill,
+		    options = layer.options,
+		    container = layer._container;
+
+		container.stroked = !!options.stroke;
+		container.filled = !!options.fill;
+
+		if (options.stroke) {
+			if (!stroke) {
+				stroke = layer._stroke = vmlCreate('stroke');
+			}
+			container.appendChild(stroke);
+			stroke.weight = options.weight + 'px';
+			stroke.color = options.color;
+			stroke.opacity = options.opacity;
+
+			if (options.dashArray) {
+				stroke.dashStyle = Util.isArray(options.dashArray) ?
+				    options.dashArray.join(' ') :
+				    options.dashArray.replace(/( *, *)/g, ' ');
+			} else {
+				stroke.dashStyle = '';
+			}
+			stroke.endcap = options.lineCap.replace('butt', 'flat');
+			stroke.joinstyle = options.lineJoin;
+
+		} else if (stroke) {
+			container.removeChild(stroke);
+			layer._stroke = null;
+		}
+
+		if (options.fill) {
+			if (!fill) {
+				fill = layer._fill = vmlCreate('fill');
+			}
+			container.appendChild(fill);
+			fill.color = options.fillColor || options.color;
+			fill.opacity = options.fillOpacity;
+
+		} else if (fill) {
+			container.removeChild(fill);
+			layer._fill = null;
+		}
+	},
+
+	_updateCircle: function (layer) {
+		var p = layer._point.round(),
+		    r = Math.round(layer._radius),
+		    r2 = Math.round(layer._radiusY || r);
+
+		this._setPath(layer, layer._empty() ? 'M0 0' :
+			'AL ' + p.x + ',' + p.y + ' ' + r + ',' + r2 + ' 0,' + (65535 * 360));
+	},
+
+	_setPath: function (layer, path) {
+		layer._path.v = path;
+	},
+
+	_bringToFront: function (layer) {
+		DomUtil.toFront(layer._container);
+	},
+
+	_bringToBack: function (layer) {
+		DomUtil.toBack(layer._container);
+	}
+};

--- a/spec/e2e/leaflet-vml/leafdoc-options.json
+++ b/spec/e2e/leaflet-vml/leafdoc-options.json
@@ -1,0 +1,5 @@
+{
+    "templateDir": "./templates/leaflet",
+    "showInheritancesWhenEmpty": true,
+    "leadingCharacter": "@"
+}

--- a/spec/e2e/leaflet-vml/leaflet-vml.expected.html
+++ b/spec/e2e/leaflet-vml/leaflet-vml.expected.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	<meta charset="utf-8">
+
+	<link rel="stylesheet" href="http://leafletjs.com/docs/css/normalize.css" />
+	<link rel="stylesheet" href="http://leafletjs.com/docs/css/main.css" />
+	<script src="http://leafletjs.com/docs/highlight/highlight.pack.js"></script>
+	<link rel="stylesheet" href="http://leafletjs.com/docs/highlight/styles/github-gist.css" />
+	<link rel="stylesheet" href="http://leafletjs.com/dist/leaflet.css" />
+	<script src="http://leafletjs.com/dist/leaflet.js"></script>
+</head>
+<body class='api-page'>
+	<div class='container'>
+
+	<h2>Leaflet API reference</h2>
+	<div id="toc" class="clearfix">
+		<div class="toc-col map-col">
+			<h4>Map</h4>
+			<ul>
+				<li><a href="#map-example">Usage example</a></li>
+				<li><a href="#map-factory">Creation</a></li>
+				<li><a href="#map-option">Options</a></li>
+				<li><a href="#map-event">Events</a></li>
+			</ul>
+			<h4>Map Methods</h4>
+			<ul>
+				<li><a href="#map-methods-for-modifying-map-state">Modifying map state</a></li>
+				<li><a href="#map-methods-for-getting-map-state">Getting map state</a></li>
+				<li><a href="#map-methods-for-layers-and-controls">Layers and controls</a></li>
+				<li><a href="#map-conversion-methods">Conversion methods</a></li>
+				<li><a href="#map-other-methods">Other methods</a></li>
+			</ul>
+			<h4>Map Misc</h4>
+			<ul>
+				<li><a href="#map-property">Properties</a></li>
+				<li><a href="#map-pane">Panes</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+			<h4>UI Layers</h4>
+			<ul>
+				<li><a href="#marker">Marker</a></li>
+				<li><a href="#popup">Popup</a></li>
+				<li><a href="#tooltip">Tooltip</a></li>
+			</ul>
+			<h4>Raster Layers</h4>
+			<ul>
+				<li><a href="#tilelayer">TileLayer</a></li>
+				<li><a href="#tilelayer-wms">TileLayer.WMS</a></li>
+				<li><a href="#imageoverlay">ImageOverlay</a></li>
+				<li><a href="#videooverlay">VideoOverlay</a></li>
+			</ul>
+			<h4>Vector Layers</h4>
+			<ul>
+				<li><a href="#path">Path</a></li>
+				<li><a href="#polyline">Polyline</a></li>
+				<li><a href="#polygon">Polygon</a></li>
+				<li><a href="#rectangle">Rectangle</a></li>
+				<li><a href="#circle">Circle</a></li>
+				<li><a href="#circlemarker">CircleMarker</a></li>
+				<li><a href="#svg">SVG</a></li>
+				<li><a href="#canvas">Canvas</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+			<h4>Other Layers</h4>
+			<ul>
+				<li><a href="#layergroup">LayerGroup</a></li>
+				<li><a href="#featuregroup">FeatureGroup</a></li>
+				<li><a href="#geojson">GeoJSON</a></li>
+				<li><a href="#gridlayer">GridLayer</a></li>
+			</ul>
+			<h4>Basic Types</h4>
+			<ul>
+				<li><a href="#latlng">LatLng</a></li>
+				<li><a href="#latlngbounds">LatLngBounds</a></li>
+				<li><a href="#point">Point</a></li>
+				<li><a href="#bounds">Bounds</a></li>
+				<li><a href="#icon">Icon</a></li>
+				<li><a href="#divicon">DivIcon</a></li>
+			</ul>
+			<h4>Controls</h4>
+			<ul>
+				<li><a href="#control-zoom">Zoom</a></li>
+				<li><a href="#control-attribution">Attribution</a></li>
+				<li><a href="#control-layers">Layers</a></li>
+				<li><a href="#control-scale">Scale</a></li>
+			</ul>
+		</div>
+		<div class="toc-col">
+<!-- 			<h4>Shared Methods</h4> -->
+<!-- 			<ul> -->
+<!-- 				<li><a href="#evented">Event</a></li> -->
+<!-- 				<li><a href="#layers">Layer</a></li> -->
+<!-- 				<li><a href="#popup">Popup</a></li> -->
+<!-- 			</ul> -->
+			<h4>Utility</h4>
+			<ul>
+				<li><a href="#browser">Browser</a></li>
+				<li><a href="#util">Util</a></li>
+				<li><a href="#transformation">Transformation</a></li>
+				<li><a href="#lineutil">LineUtil</a></li>
+				<li><a href="#polyutil">PolyUtil</a></li>
+			</ul>
+			<h4>DOM Utility</h4>
+			<ul>
+				<li><a href="#domevent">DomEvent</a></li>
+				<li><a href="#domutil">DomUtil</a></li>
+				<li><a href="#posanimation">PosAnimation</a></li>
+				<li><a href="#draggable">Draggable</a></li>
+			</ul>
+		</div>
+		<div class="toc-col last-col">
+			<h4>Base Classes</h4>
+			<ul>
+				<li><a href="#class">Class</a></li>
+				<li><a href="#evented">Evented</a></li>
+				<li><a href="#layer">Layer</a></li>
+				<li><a href="#interactive-layer">Interactive layer</a></li>
+				<li><a href="#control">Control</a></li>
+				<li><a href="#handler">Handler</a></li>
+				<!--<li><a class="nodocs" href="#">IFeature</a></li>-->
+				<li><a href="#projection">Projection</a></li>
+				<li><a href="#crs">CRS</a></li>
+				<li><a href="#renderer">Renderer</a></li>
+			</ul>
+
+			<h4>Misc</h4>
+			<ul>
+				<li><a href="#event-objects">Event objects</a></li>
+ 				<li><a href="#global-switches">global switches</a></li>
+				<li><a href="#noconflict">noConflict</a></li>
+				<li><a href="#version">version</a></li>
+			</ul>
+		</div>
+	</div>
+
+	<h2 id='svg'>SVG</h2><p>Although SVG is not available on IE7 and IE8, these browsers support <a href="https://en.wikipedia.org/wiki/Vector_Markup_Language">VML</a>, and the SVG renderer will fall back to VML in this case.</p>
+<p>VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
+with old versions of Internet Explorer.</p>
+
+
+
+
+
+	<div class="footer">
+		<p>© 2017 <a href="http://agafonkin.com/en">Vladimir Agafonkin</a>. Maps © <a 	href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors.</p>
+	</div>
+
+	</div>
+
+	<script src="http://leafletjs.com/docs/js/docs.js"></script>
+	<script>
+	hljs.configure({tabReplace: '    '});
+	hljs.initHighlightingOnLoad();
+
+	var elems = document.querySelectorAll('h2, h3, h4, tr');
+
+	for (var i = 0, len = elems.length; i < len; i++) {
+		var el = elems[i];
+
+		if (el.id) {
+			var anchor = document.createElement('a');
+			anchor.setAttribute('anchor', el.id);
+			if (!el.children.length) {
+				// For headers, insert the anchor before.
+				el.parentNode.insertBefore(anchor, el);
+			} else {
+				// For table rows, insert the anchor inside the first <td>
+				el.querySelector('td').appendChild(anchor);
+
+				// Clicking on the row (meaning "the link icon on the ::before)
+				// jumps to the item
+				el.parentNode.onclick = function(hash){
+					return function(ev) {
+						if (ev.offsetX < 0) {
+							window.location.hash = '#' + ev.target.parentNode.id;
+						}
+					};
+				}(el.id);
+			}
+		}
+	}
+
+	elems = document.querySelectorAll('div.accordion');
+	for (var i = 0, len = elems.length; i < len; i++) {
+		var el = elems[i];
+
+		el.querySelector('label').addEventListener('click', function(c){
+			return function() {
+				if (c.className === 'accordion expanded') {
+					c.className = 'accordion collapsed';
+				} else {
+					c.className = 'accordion expanded';
+				}
+			};
+		}(el));
+
+// 		el.className = 'accordion collapsed';
+// 		el.querySelector('.accordion-content').style.display = 'none';
+	}
+
+</script>
+<style>
+
+	h2 {
+		margin-top: 2em;
+	}
+
+	h3 {
+		margin-top: 1em;
+		margin-bottom: .5em;
+	}
+
+	div.accordion {
+		width: 100%;
+/* 		overflow: hidden; */
+	}
+
+	div.accordion-overflow {
+		width: 100%;
+		overflow: hidden;
+	}
+
+	label,
+	section > h4 {
+		display: block;
+		font-weight: 500;
+		margin: 1em 0 0.25em;
+	}
+
+	label {
+		cursor: pointer;
+	}
+
+	div.accordion > div.accordion-overflow > div.accordion-content {
+		max-height: 0;
+		display: none;
+	}
+
+	div.accordion.collapsed > div.accordion-overflow > div.accordion-content {
+		animation-duration: 0.4s;
+		animation-name: collapse;
+/* 		height: 0; */
+		max-height: 0;
+		display: block;
+		overflow: hidden;
+	}
+
+	div.accordion.expanded > div.accordion-overflow > div.accordion-content {
+		animation-duration: 0.4s;
+		animation-name: expand;
+/* 		height: auto; */
+		max-height: none;
+		display: block;
+	}
+
+	@keyframes collapse {
+		0% { max-height: 100vh; }
+		100% { max-height: 0; }
+	}
+
+	@keyframes expand {
+		0% { max-height: 0; }
+		100% { max-height: 100vh; }
+	}
+
+/*	div.accordion > div.accordion-content {
+		transition: max-height 0.4s ease-out 0s;
+	}*/
+
+	div.accordion.expanded > label > span.expander {
+		transform: rotate(90deg);
+	}
+
+	div.accordion > label > span.expander {
+		transition: transform 0.4s ease-out 0s;
+		display: inline-block;
+		font-size: 12px;
+	}
+
+
+	table {
+		margin-bottom: 0;
+	}
+
+/* 	Markdown renders some spurious <p>s inside the table cells */
+	td > p {
+		margin:0;
+	}
+
+/* 	This just looks bad (with the current grey headers for sections which Vlad doesn't really like, so might have to change this) */
+	section.collapsable > div.section-comments > p {
+		margin:0;
+	}
+
+	div.section-comments {
+		margin-bottom: 0.25em;
+	}
+
+/*	section.collapsable div.section-comments {
+		margin: 1em;
+		font-size: 12px;
+	}*/
+
+	section.collapsable pre {
+		margin:0;
+	}
+
+	section {
+		margin-left: 0.5em;
+	}
+
+	section h4, section.collapsable h4 {
+		margin-left: -0.5em;
+	}
+
+
+
+</style>
+</body></html>

--- a/spec/e2e/leaflet-vml/leaflet-vml.expected.json
+++ b/spec/e2e/leaflet-vml/leaflet-vml.expected.json
@@ -1,0 +1,17 @@
+{
+ "SVG": {
+  "name": "SVG",
+  "aka": [],
+  "comments": [
+   "",
+   "Although SVG is not available on IE7 and IE8, these browsers support [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language), and the SVG renderer will fall back to VML in this case.",
+   "",
+   "VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility",
+   "with old versions of Internet Explorer.",
+   ""
+  ],
+  "supersections": {},
+  "inherits": [],
+  "id": "svg"
+ }
+}

--- a/spec/leafdoc-c-like-parser-spec.js
+++ b/spec/leafdoc-c-like-parser-spec.js
@@ -178,6 +178,13 @@ bar2*/
 	 */        
         `)).toEqual(['foo\n\nbar\n']);
 
+			expect(cLikeParser(`
+	/* foo
+
+	 * bar
+	 */        
+        `)).toEqual(['foo\n\nbar\n']);
+
 
 		});
 	});
@@ -242,6 +249,28 @@ var map = L.map('map', {
 });
 \`\`\`
 
+`]);
+
+	});
+
+	it('Parses correctly Leaflet\'s VML leading comment block', function () {
+
+		expect(cLikeParser(`
+/*
+ * @class SVG
+ *
+ * Although SVG is not available on IE7 and IE8, these browsers support [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language), and the SVG renderer will fall back to VML in this case.
+ *
+ * VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
+ * with old versions of Internet Explorer.
+ */
+`)).toEqual([`
+@class SVG
+
+Although SVG is not available on IE7 and IE8, these browsers support [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language), and the SVG renderer will fall back to VML in this case.
+
+VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
+with old versions of Internet Explorer.
 `]);
 
 

--- a/spec/leafdoc-c-like-parser-spec.js
+++ b/spec/leafdoc-c-like-parser-spec.js
@@ -162,17 +162,28 @@ lorem ipsum
 /*foo2
 bar2*/
 `)).toEqual(['\nfoo\nbar\n', 'quux', 'foo2\nbar2']);
-		});
-	});
 
-	it('Parses correctly Leaflet\'s eachLayer comment block', function () {
-
-		expect(cLikeParser(`
+			expect(cLikeParser(`
 	/* foo
 	 * bar
 	 * baz
 	 */        
         `)).toEqual(['foo\nbar\nbaz\n']);
+
+
+			expect(cLikeParser(`
+	/* foo
+	 *
+	 * bar
+	 */        
+        `)).toEqual(['foo\n\nbar\n']);
+
+
+		});
+	});
+
+	it('Parses correctly Leaflet\'s eachLayer comment block', function () {
+
 
 		expect(cLikeParser(`
 	/* @method eachLayer(fn: Function, context?: Object): this
@@ -191,6 +202,48 @@ map.eachLayer(function(layer){
 });
 \`\`\`
 `]);
+	});
+
+	it('Parses correctly Leaflet\'s Map leading comment block', function () {
+
+		expect(cLikeParser(`
+/*
+ * @class Map
+ * @aka L.Map
+ * @inherits Evented
+ *
+ * The central class of the API — it is used to create a map on a page and manipulate it.
+ *
+ * @example
+ *
+ * \`\`\`js
+ * // initialize the map on the "map" div with a given center and zoom
+ * var map = L.map('map', {
+ * 	center: [51.505, -0.09],
+ * 	zoom: 13
+ * });
+ * \`\`\`
+ *
+ */
+`)).toEqual([`
+@class Map
+@aka L.Map
+@inherits Evented
+
+The central class of the API — it is used to create a map on a page and manipulate it.
+
+@example
+
+\`\`\`js
+// initialize the map on the "map" div with a given center and zoom
+var map = L.map('map', {
+	center: [51.505, -0.09],
+	zoom: 13
+});
+\`\`\`
+
+`]);
+
 
 	});
 

--- a/spec/leafdoc-c-like-parser-spec.js
+++ b/spec/leafdoc-c-like-parser-spec.js
@@ -164,5 +164,35 @@ bar2*/
 `)).toEqual(['\nfoo\nbar\n', 'quux', 'foo2\nbar2']);
 		});
 	});
+
+	it('Parses correctly Leaflet\'s eachLayer comment block', function () {
+
+		expect(cLikeParser(`
+	/* foo
+	 * bar
+	 * baz
+	 */        
+        `)).toEqual(['foo\nbar\nbaz\n']);
+
+		expect(cLikeParser(`
+	/* @method eachLayer(fn: Function, context?: Object): this
+	 * Iterates over the layers of the map, optionally specifying context of the iterator function.
+	 * \`\`\`
+	 * map.eachLayer(function(layer){
+	 *     layer.bindPopup('Hello');
+	 * });
+	 * \`\`\`
+	 */        
+        `)).toEqual([`@method eachLayer(fn: Function, context?: Object): this
+Iterates over the layers of the map, optionally specifying context of the iterator function.
+\`\`\`
+map.eachLayer(function(layer){
+    layer.bindPopup('Hello');
+});
+\`\`\`
+`]);
+
+	});
+
 });
 

--- a/spec/leafdoc-c-like-parser-spec.js
+++ b/spec/leafdoc-c-like-parser-spec.js
@@ -1,0 +1,168 @@
+/*eslint-env node,jasmine */
+
+const cLikeParser = require('../dist/split/c-like.js');
+
+
+describe('C-like parser', function () {
+	describe('when there are no comments', function () {
+
+		it('returns an empty array', () => {
+
+			expect(cLikeParser('')).toEqual([]);
+			expect(cLikeParser('foobar')).toEqual([]);
+			expect(cLikeParser('1234')).toEqual([]);
+
+			const text = `
+var path$1 = require('path');
+var Handlebars = require('handlebars');
+var templateDir = 'basic';
+`;
+
+			expect(cLikeParser(text)).toEqual([]);
+		});
+
+	});
+
+	describe('when there are single-line comments', function () {
+
+		it('returns one item of one line', () => {
+			expect(cLikeParser('//foobar')).toEqual(['foobar']);
+			expect(cLikeParser('// foobar')).toEqual(['foobar']);
+			expect(cLikeParser('//  foobar')).toEqual([' foobar']);
+			expect(cLikeParser('//\tfoobar')).toEqual(['foobar']);
+			expect(cLikeParser('//\t\tfoobar')).toEqual(['\tfoobar']);
+			expect(cLikeParser(' // foobar')).toEqual(['foobar']);
+			expect(cLikeParser('      // foobar')).toEqual(['foobar']);
+			expect(cLikeParser('      //  foobar')).toEqual([' foobar']);
+
+			expect(cLikeParser(`
+something 
+// foobar
+something else
+`)).toEqual(['foobar']);
+		});
+
+		it('returns one item of two lines', () => {
+			expect(cLikeParser('//foo\n//bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('//foo\n// bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('// foo\n//bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('// foo\n// bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('   //foo\n   //bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('   // foo\n   // bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('\t\t//foo\n\t\t//bar')).toEqual(['foo\nbar']);
+			expect(cLikeParser('\t\t// \tfoo\n\t\t// \tbar')).toEqual(['\tfoo\n\tbar']);
+
+			expect(cLikeParser(`
+something 
+// foo
+// bar
+something else
+`)).toEqual(['foo\nbar']);
+		});
+
+		it('returns several items', () => {
+			expect(cLikeParser(`
+something 
+// foo
+// bar
+something else
+// quux
+lorem ipsum
+`)).toEqual(['foo\nbar', 'quux']);
+		});
+
+	});
+
+	describe('when there are block comments', function () {
+		it('returns one item of one line', () => {
+			expect(cLikeParser('/*foobar*/')).toEqual(['foobar']);
+			expect(cLikeParser('asdf/*foobar*/qwer')).toEqual(['foobar']);
+			expect(cLikeParser('asdf\n/*foobar*/\nqwer')).toEqual(['foobar']);
+			expect(cLikeParser('asdf\n\t/*foobar*/\n\tqwer')).toEqual(['foobar']);
+
+			expect(cLikeParser('/*foobar   */')).toEqual(['foobar']);
+			expect(cLikeParser('/*foobar  \n  */')).toEqual(['foobar\n']);
+
+			expect(cLikeParser('/**foobar*/')).toEqual(['foobar']);
+			expect(cLikeParser('/**foobar**/')).toEqual(['foobar']);
+			expect(cLikeParser('/*foobar**/')).toEqual(['foobar']);
+			expect(cLikeParser('/*******foobar******/')).toEqual(['foobar']);
+		});
+
+		it('ignores asterisk-only blocks', function () {
+			expect(cLikeParser('/*************/')).toEqual([]);
+		});
+
+		it('returns one item of two lines', () => {
+			expect(cLikeParser('/*foo\nbar*/')).toEqual(['foo\nbar']);
+			expect(cLikeParser(`
+something 
+/* foo
+bar */
+something else
+`)).toEqual([' foo\nbar']);
+
+			expect(cLikeParser(`
+something 
+/* 
+foo
+bar 
+*/
+something else
+`)).toEqual(['\nfoo\nbar\n']);
+
+			expect(cLikeParser(`
+something 
+/****
+foo
+bar 
+****/
+something else
+`)).toEqual(['\nfoo\nbar\n']);
+
+			expect(cLikeParser(`
+something 
+/**
+ * foo
+ * bar 
+ */
+something else
+`)).toEqual(['\nfoo\nbar\n']);
+
+			expect(cLikeParser(`
+something 
+/**
+ *foo
+ *bar 
+ */
+something else
+`)).toEqual(['\nfoo\nbar\n']);
+
+			expect(cLikeParser(`
+something 
+/**
+ * foo
+ * bar 
+ **/
+something else
+`)).toEqual(['\nfoo\nbar\n']);
+
+		});
+
+		it('returns several items', () => {
+			expect(cLikeParser(`
+something 
+/**
+ * foo
+ * bar
+ */
+something else
+/* quux */
+lorem ipsum
+/*foo2
+bar2*/
+`)).toEqual(['\nfoo\nbar\n', 'quux', 'foo2\nbar2']);
+		});
+	});
+});
+

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -7,45 +7,45 @@ const fs = require('fs');
 // Runs one test for each subdirectory in /spec/e2e,
 // comparing the output of running leafdoc to some expected HTML & JSON files
 
-describe('e2e tests', function(){
+describe('e2e tests', function () {
 	const dirs = fs.readdirSync('./spec/e2e');
-	
+
 	console.log('Founds e2e tests: ', dirs);
-	
+
 	for (let i in dirs) {
 		const dirName = dirs[i];
 		const dir = './spec/e2e/' + dirName + '/';
-		
-		it(dirName, function() {
-			
+
+		it(dirName, function () {
+
 			let options = {};
 			try {
 				options = JSON.parse(fs.readFileSync(dir + 'leafdoc-options.json'));
 			} catch (ex) {}
-			
+
 			const doc = new Leafdoc(options);
-			
-			const testFiles = fs.readdirSync('./spec/e2e/' + dirName).
-				filter((name)=>name !== dirName + '.html').
-				filter((name)=>name !== dirName + '.json').
-				sort();
-			
-// 			console.log(testFiles);
-			
+
+			const testFiles = fs.readdirSync('./spec/e2e/' + dirName)
+				.filter((name)=>name !== dirName + '.html')
+				.filter((name)=>name !== dirName + '.json')
+				.sort();
+
+			// 			console.log(testFiles);
+
 			testFiles.forEach((filename)=>doc.addFile('./spec/e2e/' + dirName + '/' + filename, true));
-			
-			const outJson = doc.outputJSON()
+
+			const outJson = doc.outputJSON();
 			const outHtml = doc.outputStr();
-			
+
 			fs.writeFileSync(dir + dirName + '.actual.json', outJson);
 			fs.writeFileSync(dir + dirName + '.actual.html', outHtml);
 
 			const expectedHtml = fs.readFileSync(dir + dirName + '.expected.html').toString();
 			const expectedJson = JSON.parse(fs.readFileSync(dir + dirName + '.expected.json'));
-			
+
 			expect(JSON.parse(outJson)).toEqual(expectedJson);
 			expect(outHtml).toEqual(expectedHtml);
 		});
 	}
-	
+
 });

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -1,0 +1,81 @@
+/*eslint-env node,jasmine */
+
+const Leafdoc = require('../');
+
+
+const srcCode = `
+// 🍂class Math
+// 🍂function rand(): Number
+// Returns a random number between 0.0 and 1.0
+export function rand(){
+    // Do something here.
+}
+`;
+
+const expectedDocs = `<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	<meta charset="utf-8">
+	<style>
+	table {
+		border-collapse: collapse;
+	}
+	table td, table th {
+		border: 1px solid #888;
+	}
+	pre code {
+		display: inline-block;
+		background: #eee;
+	}
+	td:last-child code {
+		background: #eee;
+	}
+	body {
+		font-family: Sans;
+	}
+	</style>
+</head>
+<body>
+	<h2>Leafdoc generated API reference</h2>
+
+	<h2 id='math'>Math</h2>
+
+<h3 id='math-function'>Functions</h3>
+
+<section data-type='[object Object]'>
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='math-rand'>
+		<td><code><b>rand</b>()</nobr></code></td>
+		<td><code>Number</code></td>
+		<td>Returns a random number between 0.0 and 1.0</td>
+	</tr>
+</tbody></table>
+</section>
+
+
+
+</body></html>`;
+
+
+
+describe('Math src dode', function () {
+	it('triggers the desired output', () => {
+
+
+		const doc = new Leafdoc();
+
+		doc.addStr(srcCode, true);
+
+		expect(doc.outputStr()).toEqual(expectedDocs);
+	});
+});
+

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -4,6 +4,8 @@ const Leafdoc = require('../');
 
 const fs = require('fs');
 
+// Runs one test for each subdirectory in /spec/e2e,
+// comparing the output of running leafdoc to some expected HTML & JSON files
 
 describe('e2e tests', function(){
 	const dirs = fs.readdirSync('./spec/e2e');
@@ -16,17 +18,19 @@ describe('e2e tests', function(){
 		
 		it(dirName, function() {
 			
-			const expectedHtml = fs.readFileSync(dir + dirName + '.expected.html').toString();
-			const expectedJson = JSON.parse(fs.readFileSync(dir + dirName + '.expected.json'));
+			let options = {};
+			try {
+				options = JSON.parse(fs.readFileSync(dir + 'leafdoc-options.json'));
+			} catch (ex) {}
 			
-			const doc = new Leafdoc();
+			const doc = new Leafdoc(options);
 			
 			const testFiles = fs.readdirSync('./spec/e2e/' + dirName).
 				filter((name)=>name !== dirName + '.html').
 				filter((name)=>name !== dirName + '.json').
 				sort();
 			
-			console.log(testFiles);
+// 			console.log(testFiles);
 			
 			testFiles.forEach((filename)=>doc.addFile('./spec/e2e/' + dirName + '/' + filename, true));
 			
@@ -35,6 +39,9 @@ describe('e2e tests', function(){
 			
 			fs.writeFileSync(dir + dirName + '.actual.json', outJson);
 			fs.writeFileSync(dir + dirName + '.actual.html', outHtml);
+
+			const expectedHtml = fs.readFileSync(dir + dirName + '.expected.html').toString();
+			const expectedJson = JSON.parse(fs.readFileSync(dir + dirName + '.expected.json'));
 			
 			expect(JSON.parse(outJson)).toEqual(expectedJson);
 			expect(outHtml).toEqual(expectedHtml);
@@ -42,19 +49,3 @@ describe('e2e tests', function(){
 	}
 	
 });
-
-
-// describe('Math src dode', function () {
-// 	it('triggers the desired output', () => {
-// 
-// 		const doc = new Leafdoc();
-// 
-// 		doc.addStr(srcCode, true);
-//         
-// // 		console.log(doc.outputJSON());
-// 
-//         expect(JSON.parse(doc.outputJSON())).toEqual(expectedJson);
-// 		expect(doc.outputStr()).toEqual(expectedDocs);
-// 	});
-// });
-

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -10,6 +10,12 @@ const srcCode = `
 export function rand(){
     // Do something here.
 }
+
+// 🍂function log(x: Number): Number
+// Returns the natural logarithm (base e) of the given number
+export function log(x) {
+    // Do something
+}
 `;
 
 const expectedDocs = `<!DOCTYPE html>
@@ -58,6 +64,11 @@ const expectedDocs = `<!DOCTYPE html>
 		<td><code>Number</code></td>
 		<td>Returns a random number between 0.0 and 1.0</td>
 	</tr>
+	<tr id='math-log'>
+		<td><code><b>log</b>(<nobr>&lt;Number&gt; <i>x</i></nobr>)</nobr></code></td>
+		<td><code>Number</code></td>
+		<td>Returns the natural logarithm (base e) of the given number</td>
+	</tr>
 </tbody></table>
 </section>
 
@@ -65,16 +76,75 @@ const expectedDocs = `<!DOCTYPE html>
 
 </body></html>`;
 
-
+const expectedJson = {
+ "Math": {
+  "name": "Math",
+  "aka": [],
+  "comments": [],
+  "supersections": {
+   "function": {
+    "name": "function",
+    "aka": [],
+    "comments": [],
+    "sections": {
+     "__default": {
+      "name": "__default",
+      "aka": [],
+      "comments": [],
+      "uninheritable": false,
+      "documentables": {
+       "rand": {
+        "name": "rand",
+        "aka": [],
+        "comments": [
+         "Returns a random number between 0.0 and 1.0"
+        ],
+        "params": {},
+        "type": "Number",
+        "optional": false,
+        "defaultValue": null,
+        "id": "math-rand"
+       },
+       "log": {
+        "name": "log",
+        "aka": [],
+        "comments": [
+         "Returns the natural logarithm (base e) of the given number"
+        ],
+        "params": {
+         "x": {
+          "name": "x",
+          "type": "Number"
+         }
+        },
+        "type": "Number",
+        "optional": false,
+        "defaultValue": null,
+        "id": "math-log"
+       }
+      },
+      "type": "function",
+      "id": "math-function"
+     }
+    },
+    "id": "math-function"
+   }
+  },
+  "inherits": [],
+  "id": "math"
+ }
+};
 
 describe('Math src dode', function () {
 	it('triggers the desired output', () => {
 
-
 		const doc = new Leafdoc();
 
 		doc.addStr(srcCode, true);
+        
+// 		console.log(doc.outputJSON());
 
+        expect(JSON.parse(doc.outputJSON())).toEqual(expectedJson);
 		expect(doc.outputStr()).toEqual(expectedDocs);
 	});
 });

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -2,150 +2,59 @@
 
 const Leafdoc = require('../');
 
+const fs = require('fs');
 
-const srcCode = `
-// 🍂class Math
-// 🍂function rand(): Number
-// Returns a random number between 0.0 and 1.0
-export function rand(){
-    // Do something here.
-}
 
-// 🍂function log(x: Number): Number
-// Returns the natural logarithm (base e) of the given number
-export function log(x) {
-    // Do something
-}
-`;
-
-const expectedDocs = `<!DOCTYPE html>
-<html>
-<head>
-	<title></title>
-	<meta charset="utf-8">
-	<style>
-	table {
-		border-collapse: collapse;
+describe('e2e tests', function(){
+	const dirs = fs.readdirSync('./spec/e2e');
+	
+	console.log('Founds e2e tests: ', dirs);
+	
+	for (let i in dirs) {
+		const dirName = dirs[i];
+		const dir = './spec/e2e/' + dirName + '/';
+		
+		it(dirName, function() {
+			
+			const expectedHtml = fs.readFileSync(dir + dirName + '.expected.html').toString();
+			const expectedJson = JSON.parse(fs.readFileSync(dir + dirName + '.expected.json'));
+			
+			const doc = new Leafdoc();
+			
+			const testFiles = fs.readdirSync('./spec/e2e/' + dirName).
+				filter((name)=>name !== dirName + '.html').
+				filter((name)=>name !== dirName + '.json').
+				sort();
+			
+			console.log(testFiles);
+			
+			testFiles.forEach((filename)=>doc.addFile('./spec/e2e/' + dirName + '/' + filename, true));
+			
+			const outJson = doc.outputJSON()
+			const outHtml = doc.outputStr();
+			
+			fs.writeFileSync(dir + dirName + '.actual.json', outJson);
+			fs.writeFileSync(dir + dirName + '.actual.html', outHtml);
+			
+			expect(JSON.parse(outJson)).toEqual(expectedJson);
+			expect(outHtml).toEqual(expectedHtml);
+		});
 	}
-	table td, table th {
-		border: 1px solid #888;
-	}
-	pre code {
-		display: inline-block;
-		background: #eee;
-	}
-	td:last-child code {
-		background: #eee;
-	}
-	body {
-		font-family: Sans;
-	}
-	</style>
-</head>
-<body>
-	<h2>Leafdoc generated API reference</h2>
-
-	<h2 id='math'>Math</h2>
-
-<h3 id='math-function'>Functions</h3>
-
-<section data-type='[object Object]'>
-
-
-<table><thead>
-	<tr>
-		<th>Function</th>
-		<th>Returns</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='math-rand'>
-		<td><code><b>rand</b>()</nobr></code></td>
-		<td><code>Number</code></td>
-		<td>Returns a random number between 0.0 and 1.0</td>
-	</tr>
-	<tr id='math-log'>
-		<td><code><b>log</b>(<nobr>&lt;Number&gt; <i>x</i></nobr>)</nobr></code></td>
-		<td><code>Number</code></td>
-		<td>Returns the natural logarithm (base e) of the given number</td>
-	</tr>
-</tbody></table>
-</section>
-
-
-
-</body></html>`;
-
-const expectedJson = {
- "Math": {
-  "name": "Math",
-  "aka": [],
-  "comments": [],
-  "supersections": {
-   "function": {
-    "name": "function",
-    "aka": [],
-    "comments": [],
-    "sections": {
-     "__default": {
-      "name": "__default",
-      "aka": [],
-      "comments": [],
-      "uninheritable": false,
-      "documentables": {
-       "rand": {
-        "name": "rand",
-        "aka": [],
-        "comments": [
-         "Returns a random number between 0.0 and 1.0"
-        ],
-        "params": {},
-        "type": "Number",
-        "optional": false,
-        "defaultValue": null,
-        "id": "math-rand"
-       },
-       "log": {
-        "name": "log",
-        "aka": [],
-        "comments": [
-         "Returns the natural logarithm (base e) of the given number"
-        ],
-        "params": {
-         "x": {
-          "name": "x",
-          "type": "Number"
-         }
-        },
-        "type": "Number",
-        "optional": false,
-        "defaultValue": null,
-        "id": "math-log"
-       }
-      },
-      "type": "function",
-      "id": "math-function"
-     }
-    },
-    "id": "math-function"
-   }
-  },
-  "inherits": [],
-  "id": "math"
- }
-};
-
-describe('Math src dode', function () {
-	it('triggers the desired output', () => {
-
-		const doc = new Leafdoc();
-
-		doc.addStr(srcCode, true);
-        
-// 		console.log(doc.outputJSON());
-
-        expect(JSON.parse(doc.outputJSON())).toEqual(expectedJson);
-		expect(doc.outputStr()).toEqual(expectedDocs);
-	});
+	
 });
+
+
+// describe('Math src dode', function () {
+// 	it('triggers the desired output', () => {
+// 
+// 		const doc = new Leafdoc();
+// 
+// 		doc.addStr(srcCode, true);
+//         
+// // 		console.log(doc.outputJSON());
+// 
+//         expect(JSON.parse(doc.outputJSON())).toEqual(expectedJson);
+// 		expect(doc.outputStr()).toEqual(expectedDocs);
+// 	});
+// });
 

--- a/spec/leafdoc-e2e-spec.js
+++ b/spec/leafdoc-e2e-spec.js
@@ -26,8 +26,8 @@ describe('e2e tests', function () {
 			const doc = new Leafdoc(options);
 
 			const testFiles = fs.readdirSync('./spec/e2e/' + dirName)
-				.filter((name)=>name !== dirName + '.html')
-				.filter((name)=>name !== dirName + '.json')
+				.filter((name)=>!name.match(/\.html$/))
+				.filter((name)=>!name.match(/\.json$/))
 				.sort();
 
 			// 			console.log(testFiles);

--- a/spec/leafdoc-trivial-parser-spec.js
+++ b/spec/leafdoc-trivial-parser-spec.js
@@ -1,0 +1,35 @@
+/*eslint-env node,jasmine */
+
+const trivialParser = require('../dist/split/trivial.js');
+
+
+describe('Trivial parser', function () {
+	it('just passes the string around, wrapped in an array', () => {
+
+		expect(trivialParser('foobar')).toEqual(['foobar']);
+
+		const text = `
+var path$1 = require('path');
+var Handlebars = require('handlebars');
+
+var templateDir = 'basic';
+      
+// marked.setOptions({
+// 	highlight: function (code) {
+// 		return require('highlight').highlight(code).value;
+// 	}
+// });
+
+var _AKAs = {};
+
+/* function setAKAs(akas) {
+
+// 	console.log('Template thing updating AKAs');
+	_AKAs = akas;
+} */
+`;
+
+		expect(trivialParser(text)).toEqual([text]);
+	});
+
+});

--- a/spec/specRunner.html
+++ b/spec/specRunner.html
@@ -1,0 +1,23 @@
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Jasmine Spec Runner v2.0.0</title>
+
+<link rel="shortcut icon" type="image/png" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine_favicon.png">
+<link rel="stylesheet" type="text/css" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+
+<script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+<script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+<script type="text/javascript" src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+
+
+
+<script>
+window.module = {};
+</script>
+<script type="text/javascript" src="../src/parsers/c-like.js"></script>
+<script type="text/javascript" src="../src/parsers/trivial.js"></script>
+
+<script type="text/javascript" src="intel-hex-parse-spec.js"></script>
+<script type="text/javascript" src="intel-hex-blocks-spec.js"></script>
+
+</head></html>

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,7 +21,7 @@ var sander = require('sander');
 var Leafdoc = require('./leafdoc');
 var path = require('path');
 
-var argv = minimist( process.argv.slice( 2 ), {
+var argv = minimist(process.argv.slice(2), {
 	alias: {
 		// 🍂option template: String='templates/basic'; Akin to [Leafdoc.templateDir](#leafdoc.templatedir)
 		// 🍂option t; Alias of `template`
@@ -41,7 +41,7 @@ var argv = minimist( process.argv.slice( 2 ), {
 	},
 	boolean: ['v', 'verbose', 'j', 'json'],
 	string: ['t', 'template', 'c', 'character'],
-	default: { verbose: false, template: 'templates/basic', character: '🍂' }
+	default: {verbose: false, template: 'templates/basic', character: '🍂'}
 });
 
 var doc = new Leafdoc({
@@ -50,7 +50,7 @@ var doc = new Leafdoc({
 	character: argv.character
 });
 
-argv._.forEach( function(filepath) {
+argv._.forEach(function (filepath) {
 	try {
 		var stats = sander.statSync(filepath);
 
@@ -61,10 +61,10 @@ argv._.forEach( function(filepath) {
 		if (stats.isDirectory()) {
 			doc.addDir(filepath);
 		}
-	} catch(e) {
+	} catch (e) {
 		throw e;
 	}
-} );
+});
 
 var out;
 if (argv.json) {

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -113,7 +113,7 @@ console.log( doc.outputStr() );
 // template file for it.
 // Set `label` to the text for the sections in the generated docs.
 // `inheritable` parameter determines documentable can be inherited via inherits keyword in a subclass.
-Leafdoc.prototype.registerDocumentable = function(name, label, inheritable) {
+Leafdoc.prototype.registerDocumentable = function (name, label, inheritable) {
 
 	this._knownDocumentables.push(name, label);
 
@@ -131,7 +131,7 @@ Leafdoc.prototype.registerDocumentable = function(name, label, inheritable) {
 // 🍂method getTemplateEngine(): Handlebars
 // Returns handlebars template engine used to render templates.
 // You can use it for override helpers or register new.
-Leafdoc.prototype.getTemplateEngine = function() {
+Leafdoc.prototype.getTemplateEngine = function () {
 	return template.engine;
 };
 
@@ -143,7 +143,7 @@ Leafdoc.prototype.getTemplateEngine = function() {
 // The new leading character will apply only to files/dirs/strings parsed from
 // that moment on, so it's a good idea to call this before anything else.
 Leafdoc.prototype.setLeadingCharacter = function (char) {
-    console.log('Setting leading character to', char);
+	console.log('Setting leading character to', char);
 	regexps.redoLeafDirective(char);
 };
 
@@ -232,8 +232,8 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 		const commentBlock = parsedBlocks[i];
 
 		var blockIsEmpty = true;
-//         console.error('new block: ', commentBlock);
-        console.log('new block');
+		//         console.error('new block: ', commentBlock);
+		console.log('new block');
 
 		// 		if (multilineComment) {
 		// 			console.log('multiline block: {{{\n', multilineComment , '}}}');
@@ -261,22 +261,22 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 			// 			var match = regex.exec(line);	// Skips extra comment characters
 			// 			var lineStr = match[1];
-				// Might happen in some binary files
-				console.log(line);
-				break;
-			}
+			// Might happen in some binary files
+			// 				console.log(line);
+			// 				break;
+			// 			}
 			var lineIsValid = false;
 			var parsedCharacters = 0;
 
-            console.log('Line: ', i, line);
+			console.log('Line: ', i, line);
 			// 			var match = regex.exec(line);
 
 			let match;
-				// In "param foo, bar", directive is "param" and content is "foo, bar"
+			// In "param foo, bar", directive is "param" and content is "foo, bar"
 			while (match = regexps.leafDirective.exec(line)) {
 				if (match[2]) { match[2] = match[2].trim(); }
 				directives.push([match[1], match[2]]);	// [directive, content]
-                console.log('directive match: ', match);
+				console.log('directive match: ', match);
 				blockIsEmpty = false;
 				lineIsValid = true;
 				parsedCharacters = match.index + match[0].length;
@@ -297,7 +297,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			}
 		}
 
-        console.log('directives', directives);
+		console.log('directives', directives);
 
 		for (let i in directives) {
 			var directive = directives[i][0],
@@ -335,7 +335,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			}
 
 
-// 				console.log(scope, '-', directive, '-', content);
+			// 				console.log(scope, '-', directive, '-', content);
 
 			if (scope === 'ns') {
 				if (!namespaces.hasOwnProperty(ns)) {
@@ -414,18 +414,20 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 					// 						console.log(content, ', ', alt);
 
-					let name, paramString, params = {}, type = null, defaultValue = null, optional=false;
+					let name, paramString, params = {}, type = null, defaultValue = null, optional = false;
 
 					if (content) {
 						let split = regexps.functionDefinition.exec(content);
 						if (!split) {
 							console.error('Invalid ' + directive + ' definition: ', content);
 						} else {
-							[, name, paramString, type, defaultValue] = split;
+							optional = split[2] == '?';
+							[, name,, paramString, type, defaultValue] = split;
+
 							// 							name = split[1];
-							// 							paramString = split[2];
-							// 							type = split[3];
-							// 							defaultValue = split[4];
+							// 							paramString = split[3];
+							// 							type = split[4];
+							// 							defaultValue = split[5];
 
 							if (paramString) {
 								let match;
@@ -528,7 +530,7 @@ Leafdoc.prototype.outputStr = function () {
  * Outputs the internal documentation tree to a JSON blob, without any formatting.
  * Use only after all the needed files have been parsed.
  */
-Leafdoc.prototype.outputJSON = function() {
+Leafdoc.prototype.outputJSON = function () {
 	this._resolveAKAs();
 	return JSON.stringify(this._namespaces, undefined, 1);
 };
@@ -739,7 +741,7 @@ Leafdoc.prototype._stringifySection = function (section, documentableType, inher
 		name: name,
 		id: section.id,
 		comments: section.comments,
-		documentables:(getTemplate(documentableType))({
+		documentables: (getTemplate(documentableType))({
 			documentables: docs
 		}),
 		isSecondarySection: (section.name !== '__default' && documentableType !== 'example' && !inheritingNamespace),

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -143,7 +143,7 @@ Leafdoc.prototype.getTemplateEngine = function () {
 // The new leading character will apply only to files/dirs/strings parsed from
 // that moment on, so it's a good idea to call this before anything else.
 Leafdoc.prototype.setLeadingCharacter = function (char) {
-	console.log('Setting leading character to', char);
+// 	console.log('Setting leading character to', char);
 	regexps.redoLeafDirective(char);
 };
 
@@ -233,7 +233,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 		var blockIsEmpty = true;
 		//         console.error('new block: ', commentBlock);
-		console.log('new block');
+// 		console.log('new block');
 
 		// 		if (multilineComment) {
 		// 			console.log('multiline block: {{{\n', multilineComment , '}}}');
@@ -268,7 +268,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			var lineIsValid = false;
 			var parsedCharacters = 0;
 
-			console.log('Line: ', i, line);
+// 			console.log('Line: ', i, line);
 			// 			var match = regex.exec(line);
 
 			let match;
@@ -276,7 +276,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			while (match = regexps.leafDirective.exec(line)) {
 				if (match[2]) { match[2] = match[2].trim(); }
 				directives.push([match[1], match[2]]);	// [directive, content]
-				console.log('directive match: ', match);
+// 				console.log('directive match: ', match);
 				blockIsEmpty = false;
 				lineIsValid = true;
 				parsedCharacters = match.index + match[0].length;
@@ -297,7 +297,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			}
 		}
 
-		console.log('directives', directives);
+// 		console.log('directives', directives);
 
 		for (let i in directives) {
 			var directive = directives[i][0],

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -233,7 +233,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 		var blockIsEmpty = true;
 		//         console.error('new block: ', commentBlock);
-// 		console.log('new block');
+		// 		console.log('new block');
 
 		// 		if (multilineComment) {
 		// 			console.log('multiline block: {{{\n', multilineComment , '}}}');
@@ -268,7 +268,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			var lineIsValid = false;
 			var parsedCharacters = 0;
 
-// 			console.log('Line: ', i, line);
+			// 			console.log('Line: ', i, line);
 			// 			var match = regex.exec(line);
 
 			let match;
@@ -276,7 +276,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			while (match = regexps.leafDirective.exec(line)) {
 				if (match[2]) { match[2] = match[2].trim(); }
 				directives.push([match[1], match[2]]);	// [directive, content]
-// 				console.log('directive match: ', match);
+				// 				console.log('directive match: ', match);
 				blockIsEmpty = false;
 				lineIsValid = true;
 				parsedCharacters = match.index + match[0].length;
@@ -297,7 +297,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 			}
 		}
 
-// 		console.log('directives', directives);
+		// 		console.log('directives', directives);
 
 		for (let i in directives) {
 			var directive = directives[i][0],

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -284,20 +284,20 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 			if (lineIsValid) {
 				// 				console.log('After having matched a line:', match);
-				var trailing = line.substr(parsedCharacters + 1).trim();
+				let trailing = line.substr(parsedCharacters + 1).trim();
 				// 				console.log('After having matched a line:', trailing);
 				if (trailing) {
 					directives.push(['comment', trailing]);
 				}
 			}
 
-			if (!lineIsValid && !blockIsEmpty && line) {
+			if (!lineIsValid && !blockIsEmpty) {
 				// implicit 🍂comment directive.
 				directives.push(['comment', line]);
 			}
 		}
 
-		// 		console.log('directives', directives);
+		// 	console.log('directives', directives);
 
 		for (let i in directives) {
 			var directive = directives[i][0],
@@ -305,7 +305,7 @@ Leafdoc.prototype.addStr = function (str, isSource) {
 
 			// 4: Parse 🍂 directives
 
-			//             console.log(directive, '-', content);
+			// console.log(directive, '-', content);
 
 			if (directive === 'class' || directive === 'namespace') {
 				ns = content.trim();

--- a/src/parsers/c-like.js
+++ b/src/parsers/c-like.js
@@ -85,14 +85,12 @@ export default function cLikeParser(str) {
 				// Remove as much leading whitespace as the last line and then an asterisk,
 				// if every line in the middle of block has that much whitespace and then an asterisk
 				if (lastLine.trim() === '') {
-					//                     console.log('Last line is only whitespace');
 					const lastLineRegexp = new RegExp('^' + lastLine + '\\*');
 					if (middleLines.every((line)=>line.match(lastLineRegexp))) {
-						//                         console.log('Middle lines have the same whitespace');
 						middleLines = middleLines.map((line)=>line.replace(/^\s*\*/, ''));
-
-						// Remove one leading whitespace, if every line in the middle block has it.
-						if (middleLines.every((line)=>line.match(/^\s/))) {
+						// Remove one leading whitespace, if every line in the middle block has it
+						// (or the line is empty)
+						if (middleLines.every((line)=>line.match(/^\s/) || line === '')) {
 							middleLines = middleLines.map((line)=>line.replace(/^\s/, ''));
 							firstLine = firstLine.replace(/^\s/, '');
 						}

--- a/src/parsers/c-like.js
+++ b/src/parsers/c-like.js
@@ -76,21 +76,30 @@ export default function cLikeParser(str) {
 				// Just trim whitespace around
 				lines[0] = lines[0].trim();
 			} else {
-				const firstLine = lines[0];
+				let firstLine = lines[0];
 				const lastLine = lines[lines.length - 1];
+
 
 				let middleLines = lines.slice(1, lines.length - 1); // Skip the first and last lines
 
-				// Remove leading whitespace+asterisk, if every line in the middle of block has them
-				if (middleLines.every((line)=>line.match(/^\s?\*/))) {
-					middleLines = middleLines.map((line)=>line.replace(/^\s?\*/, ''));
+				// Remove as much leading whitespace as the last line and then an asterisk,
+				// if every line in the middle of block has that much whitespace and then an asterisk
+				if (lastLine.trim() === '') {
+					//                     console.log('Last line is only whitespace');
+					const lastLineRegexp = new RegExp('^' + lastLine + '\\*');
+					if (middleLines.every((line)=>line.match(lastLineRegexp))) {
+						//                         console.log('Middle lines have the same whitespace');
+						middleLines = middleLines.map((line)=>line.replace(/^\s*\*/, ''));
 
-					// Remove one leading whitespace, if every line in the middle block has it.
-					if (middleLines.every((line)=>line.match(/^\s/))) {
-						middleLines = middleLines.map((line)=>line.replace(/^\s/, ''));
+						// Remove one leading whitespace, if every line in the middle block has it.
+						if (middleLines.every((line)=>line.match(/^\s/))) {
+							middleLines = middleLines.map((line)=>line.replace(/^\s/, ''));
+							firstLine = firstLine.replace(/^\s/, '');
+						}
 					}
 				}
 				lines = ([firstLine]).concat(middleLines, [lastLine]);
+				// console.log(JSON.stringify(blockComment), ",", JSON.stringify(lastLine), '→', lines.map(JSON.stringify));
 			}
 
 			const cleanBlock = lines

--- a/src/parsers/c-like.js
+++ b/src/parsers/c-like.js
@@ -86,7 +86,7 @@ export default function cLikeParser(str) {
 				// if every line in the middle of block has that much whitespace and then an asterisk
 				if (lastLine.trim() === '') {
 					const lastLineRegexp = new RegExp('^' + lastLine + '\\*');
-					if (middleLines.every((line)=>line.match(lastLineRegexp))) {
+					if (middleLines.every((line)=>line.match(lastLineRegexp) || line === '')) {
 						middleLines = middleLines.map((line)=>line.replace(/^\s*\*/, ''));
 						// Remove one leading whitespace, if every line in the middle block has it
 						// (or the line is empty)

--- a/src/parsers/c-like.js
+++ b/src/parsers/c-like.js
@@ -1,0 +1,105 @@
+
+// Regexp and their explanation:
+
+//    ^|\n|\r                                Starts at beginning, or after newline
+// (?:       )                               Non-capturing group
+//                             \/\/          Two forward slashes
+//                                 .*        Any number of non-newline characters
+//                          \s*              Any number of whitespace before the slashes...
+//                (?![\n\r])                 ...but not a newline.
+//                                   \s      A whitespace/newline at the end
+//                                     ?     But just maybe?
+//                (?![\n\r])\s*\/\/.*\s?     Whitespace, slashes, text, maybe a newline
+//             (                        )+   One or more comment lines
+//             (?:                      )    Do not capture individual lines
+//            (                           )  Capture the whole set of contiguous lines instead
+//
+// (?:^|\n|\r)((?:(?![\n\r])\s*\/\/.*\s?)+)
+
+
+//                   [\s\S]+         Any character, 1 or more times
+//                          ?        But lazy, in order to not match ending asterisks
+//                  (        )       Capture this
+//                            \*+    At least one asterisk at the end...
+//                               \/  ...and just one forward slash.
+//    \/                             Just one forward slash at the beginning...
+//      \*+                          ...and at least one asterisk
+//         (?!\*|\/)                 Do not match if the next thing is an asterisk or slash
+//                                     (if not, this will match "/****/ foobar /* */" whole)
+//                                     (i.e. the first character of [\s\S]+ must be non-asterisk,
+//                                      non-slash)
+// (?:                             ) Do not capture the whole thing
+// (?:\/\*+(?!\*|\/)([\s\S]+?)\*+\/)
+
+
+// (      multiple single lines           )|(            block              )
+// (?:^|\n|\r)((?:(?![\n\r])\s*\/\/.*\s?)+)|(?:\/\*+(?!\*|\/)([\s\S]+?)\*+\/)
+
+
+const commentRegexp = /(?:^|\n|\r)((?:(?![\n\r])\s*\/\/.*\s?)+)|(?:\/\*+(?!\*|\/)([\s\S]+?)\*+\/)/g;
+
+const leadingDoubleSlashRegexp = /\s\/\//;
+
+// Parser for c-like files/strings
+// Parses:
+// - Comment blocks with /* */, ignoring any extra asterisk like /** */ and /*** ***/
+// - Single-line comments with //, prepended only by whitespace
+// - Joins multiple single-line comments as a single block
+// - The *first* whitespace (or tab) of all single-line comments is ignored
+
+export default function cLikeParser(str) {
+	let match;
+	let parsed = [];
+
+	while (match = commentRegexp.exec(str)) {
+
+		const multilineComment = match[1];
+		const blockComment = match[2];
+
+		if (multilineComment) {
+			const cleanMultiline = multilineComment
+				.split('\n')
+				.filter((line)=>line !== '')
+				.map((line)=>
+					line
+						.replace(/\s*\/\/\s?/, '') // Remove leading double slash, *first* whitespace
+						.replace(/\s*$/, '') // Remove trailing whitespace
+				)
+				.join('\n');
+
+			parsed.push(cleanMultiline);
+		} else if (blockComment) {
+
+			let lines = blockComment.split('\n');
+
+			if (lines.length === 1) {
+				// Just trim whitespace around
+				lines[0] = lines[0].trim();
+			} else {
+				const firstLine = lines[0];
+				const lastLine = lines[lines.length - 1];
+
+				let middleLines = lines.slice(1, lines.length - 1); // Skip the first and last lines
+
+				// Remove leading whitespace+asterisk, if every line in the middle of block has them
+				if (middleLines.every((line)=>line.match(/^\s?\*/))) {
+					middleLines = middleLines.map((line)=>line.replace(/^\s?\*/, ''));
+
+					// Remove one leading whitespace, if every line in the middle block has it.
+					if (middleLines.every((line)=>line.match(/^\s/))) {
+						middleLines = middleLines.map((line)=>line.replace(/^\s/, ''));
+					}
+				}
+				lines = ([firstLine]).concat(middleLines, [lastLine]);
+			}
+
+			const cleanBlock = lines
+				.map((line)=> line.replace(/\s*$/, '')) // Remove trailing whitespace
+				.join('\n');
+
+			parsed.push(cleanBlock);
+		}
+	}
+	return parsed;
+}
+

--- a/src/parsers/trivial.js
+++ b/src/parsers/trivial.js
@@ -1,0 +1,10 @@
+
+// Trivial file/Str parser.
+// Assumes that the whole string is leafdoc docstrings.
+// This is the old 'isSource=false' behaviour.
+
+export default function trivialParser(str) {
+	// Return an array with just one element, the whole string.
+	return [str];
+}
+

--- a/src/regexps.js
+++ b/src/regexps.js
@@ -1,29 +1,29 @@
 
 // Regexps (maybe) shared between files.
 
-import { XRegExp } from 'xregexp';
+import {XRegExp} from 'xregexp';
 
 
 // One or more lines starting with whitespace and two or more forward slashes,
 // or
 // whitespace-slash-asterisk whatever asterisk-slash.
-export var commentBlock = XRegExp('^(?<multiline> ( (?!\\n) \\s*\\/{2,}\\s*.*\\n )+ ) \
+export const commentBlock = XRegExp('^(?<multiline> ( (?!\\n) \\s*\\/{2,}\\s*.*\\n )+ ) \
 | \
 (\\s*\\/\\* (?<block> [\\s\\S]*?) \\*\\/)  \
 ', 'gmnx');
 
-export var leafdocFile = XRegExp('^(?<block> [\\s\\S]+ )$', 'gmnx');
+export const leafdocFile = XRegExp('^(?<block> [\\s\\S]+ )$', 'gmnx');
 
 
 // Inside each line of a comment /* */ block, skips the leading spaces / asterisk (if any)
-export var leadingBlock = XRegExp('^  ( \\s* \\* \\s? )?   (?<line> .* )  $', 'nx');
+export const leadingBlock = XRegExp('^  ( \\s* \\* \\s? )?   (?<line> .* )  $', 'nx');
 
 
 // Inside each line of a comment // block, skips the leading //
-export var leadingLine = XRegExp('^ \\s*/{0,4}\\s{0,1} (?<line> .* )  $', 'nx');
+export const leadingLine = XRegExp('^ \\s*/{0,4}\\s{0,1} (?<line> .* )  $', 'nx');
 
 // Inside .leafdoc files, match any line without skipping anything
-export var anyLine = XRegExp('^ (?<line> .* ) $', 'nx');
+export const anyLine = XRegExp('^ (?<line> .* ) $', 'nx');
 
 
 
@@ -38,7 +38,7 @@ export const leafDirective = redoLeafDirective('🍂');
 
 // Parses an identifier, allowing only unicode ID_Start and ID_Continue characters
 // An identifier allows dots in it, to allow for namespacing identifiers.
-var identifier= XRegExp.build('^({{ID_Start}}  ( {{ID_Continue}} | \\. | : )*)$', {
+var identifier = XRegExp.build('^({{ID_Start}}  ( {{ID_Continue}} | \\. | : )*)$', {
 	ID_Start: require('unicode-7.0.0/properties/ID_Start/regex'),
 	ID_Continue: require('unicode-7.0.0/properties/ID_Continue/regex')
 }, 'nx');
@@ -46,7 +46,7 @@ var identifier= XRegExp.build('^({{ID_Start}}  ( {{ID_Continue}} | \\. | : )*)$'
 // Parses a function name, its return type, and its parameters
 // Funny thing about functions is that not all printable characters are allowed. Thus,
 //   use unicode ID_Start and ID_Continue character sets via 'identifier' sub-regexp.
-var functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) (?<required> (\\?{0,1}) ) \\s* (?<params> \\( .* \\) ){0,1}   \\s* ( \\: \\s* (?<type> .+? ) )? ( = \\s* (?<default> .+ ) \\s* ){0,1} \$', {
+export const functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) (?<required> (\\?{0,1}) ) \\s* (?<params> \\( .* \\) ){0,1}   \\s* ( \\: \\s* (?<type> .+? ) )? ( = \\s* (?<default> .+ ) \\s* ){0,1} \$', {
 	identifier: identifier
 }, 'nx');
 
@@ -54,10 +54,10 @@ var functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) (?<required>
 
 // var functionParam = XRegExp.build('^ \\s* (?<name> {{identifier}}) \\s* ( \\: \\s* (?<type> .+ ) \\s* ) $', {identifier: identifier}, 'nx');
 // var functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* ) (, | \\)) ', {identifier: identifier}, 'gnx');
-export var functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* )? (, | \\)) ', {identifier: identifier}, 'gnx');
+export const functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* )? (, | \\)) ', {identifier: identifier}, 'gnx');
 
 
 
 // Parses a miniclass name and its real class between parentheses.
-export var miniclassDefinition = XRegExp('^ (?<miniclass> .+ ) \\s* \\( (?<realclass> .+ ) \\) $', 'nx');
+export const miniclassDefinition = XRegExp('^ (?<miniclass> .+ ) \\s* \\( (?<realclass> .+ ) \\) $', 'nx');
 

--- a/src/regexps.js
+++ b/src/regexps.js
@@ -1,40 +1,39 @@
 
 // Regexps (maybe) shared between files.
 
-var XRegExp = require('xregexp').XRegExp;
+import { XRegExp } from 'xregexp';
 
 
 // One or more lines starting with whitespace and two or more forward slashes,
 // or
 // whitespace-slash-asterisk whatever asterisk-slash.
-var commentBlock = XRegExp('^(?<multiline> ( (?!\\n) \\s*\\/{2,}\\s*.*\\n )+ ) \
+export var commentBlock = XRegExp('^(?<multiline> ( (?!\\n) \\s*\\/{2,}\\s*.*\\n )+ ) \
 | \
 (\\s*\\/\\* (?<block> [\\s\\S]*?) \\*\\/)  \
-','gmnx');
+', 'gmnx');
 
-var leafdocFile = XRegExp('^(?<block> [\\s\\S]+ )$', 'gmnx');
+export var leafdocFile = XRegExp('^(?<block> [\\s\\S]+ )$', 'gmnx');
 
 
 // Inside each line of a comment /* */ block, skips the leading spaces / asterisk (if any)
-var leadingBlock = XRegExp('^  ( \\s* \\* \\s? )?   (?<line> .* )  $','nx');
+export var leadingBlock = XRegExp('^  ( \\s* \\* \\s? )?   (?<line> .* )  $', 'nx');
 
 
 // Inside each line of a comment // block, skips the leading //
-var leadingLine = XRegExp('^ \\s*/{0,4}\\s{0,1} (?<line> .* )  $','nx');
+export var leadingLine = XRegExp('^ \\s*/{0,4}\\s{0,1} (?<line> .* )  $', 'nx');
 
 // Inside .leafdoc files, match any line without skipping anything
-var anyLine = XRegExp('^ (?<line> .* ) $','nx');
+export var anyLine = XRegExp('^ (?<line> .* ) $', 'nx');
 
 
-// Parses a 🍂 directive, init'd at redoLeafDirective()
-var leafDirective;
 
 // Re-builds the 🍂 directive based on a different leading character
-function redoLeafDirective(char) {
+export function redoLeafDirective(char) {
 	return leafDirective = XRegExp('  \\s* ' + char + ' (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} ', 'gnx');
 }
 
-redoLeafDirective('🍂');
+// Parses a 🍂 directive, init'd at redoLeafDirective()
+export const leafDirective = redoLeafDirective('🍂');
 
 
 // Parses an identifier, allowing only unicode ID_Start and ID_Continue characters
@@ -49,31 +48,16 @@ var identifier= XRegExp.build('^({{ID_Start}}  ( {{ID_Continue}} | \\. | : )*)$'
 //   use unicode ID_Start and ID_Continue character sets via 'identifier' sub-regexp.
 var functionDefinition = XRegExp.build('^ (?<name> {{identifier}} ) (?<required> (\\?{0,1}) ) \\s* (?<params> \\( .* \\) ){0,1}   \\s* ( \\: \\s* (?<type> .+? ) )? ( = \\s* (?<default> .+ ) \\s* ){0,1} \$', {
 	identifier: identifier
-},'nx');
+}, 'nx');
 
 
 
 // var functionParam = XRegExp.build('^ \\s* (?<name> {{identifier}}) \\s* ( \\: \\s* (?<type> .+ ) \\s* ) $', {identifier: identifier}, 'nx');
 // var functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* ) (, | \\)) ', {identifier: identifier}, 'gnx');
-var functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* )? (, | \\)) ', {identifier: identifier}, 'gnx');
+export var functionParam = XRegExp.build('\\s* (?<name> ( {{identifier}} | … ) \\?{0,1} ) \\s* ( \\: \\s* (?<type> [^,]+ ) \\s* )? (, | \\)) ', {identifier: identifier}, 'gnx');
 
 
 
 // Parses a miniclass name and its real class between parentheses.
-var miniclassDefinition = XRegExp('^ (?<miniclass> .+ ) \\s* \\( (?<realclass> .+ ) \\) $','nx');
-
-
-module.exports = {
-	commentBlock: commentBlock,
-	leafdocFile: leafdocFile,
-	leadingBlock: leadingBlock,
-	leadingLine: leadingLine,
-	anyLine: anyLine,
-	leafDirective: leafDirective,
-	functionDefinition: functionDefinition,
-	functionParam: functionParam,
-	miniclassDefinition: miniclassDefinition,
-	redoLeafDirective: redoLeafDirective
-}
-
+export var miniclassDefinition = XRegExp('^ (?<miniclass> .+ ) \\s* \\( (?<realclass> .+ ) \\) $', 'nx');
 

--- a/src/template.js
+++ b/src/template.js
@@ -11,14 +11,14 @@ let templateDir = __dirname + '/../templates/basic';
 let templates = Object.create(null);
 
 export function setTemplateDir(newDir) {
-    templates = Object.create(null);
+	templates = Object.create(null);
 	templateDir = newDir;
 }
 
 export function getTemplate(templateName) {
 	if (!templates[templateName]) {
 		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
-    }
+	}
 	return templates[templateName];
 }
 

--- a/src/template.js
+++ b/src/template.js
@@ -1,18 +1,20 @@
 
 // Minor wrapper over Handlebars
 
-var sander = require('sander');
-var path = require('path');
-var Handlebars = require('handlebars');
+import sander from 'sander';
+import path from 'path';
+import Handlebars from 'handlebars';
+import marked from 'marked';
+export { Handlebars };
 
-var templateDir = __dirname + '/../templates/basic';
-var templates = Object.create(null)
+let templateDir = __dirname + '/../templates/basic';
+let templates = Object.create(null)
 
-exports.setTemplateDir = function(newDir) {
+export function setTemplateDir(newDir) {
 	templateDir = newDir;
-};
+}
 
-exports.getTemplate = function(templateName) {
+export function getTemplate(templateName) {
 	if (!templates[templateName]) {
 		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
 	}
@@ -22,18 +24,13 @@ exports.getTemplate = function(templateName) {
 
 var _AKAs = {};
 
-exports.setAKAs = function(akas){
+export function setAKAs(akas) {
 
 // 	console.log('Template thing updating AKAs');
 	_AKAs = akas;
-};
+}
 
-exports.engine = Handlebars;
-
-
-
-
-var marked = require('marked');
+export Handlebars as engine;
 
 
 /// TODO: Catch all code blocks and check if the contents is a known class, namespace or AKA
@@ -66,19 +63,19 @@ function replaceAKAs(str) {
 
 
 
-Handlebars.registerHelper('markdown', function(str) {
+Handlebars.registerHelper('markdown', function (str) {
 	if (!str) return;
 	if (str instanceof Array) {
 		str = str.join('\n').trim();
-// 		str = str.join(' ');
+		// 		str = str.join(' ');
 	}
 	return marked(replaceAKAs(str))
 		.trim()
-		.replace('<p>','')
-		.replace('</p>','');
+		.replace('<p>', '')
+		.replace('</p>', '');
 });
 
-Handlebars.registerHelper('rawmarkdown', function(str) {
+Handlebars.registerHelper('rawmarkdown', function (str) {
 	if (!str) { return; }
 	if (str instanceof Array) {
 		str = str.join('\n');
@@ -88,11 +85,11 @@ Handlebars.registerHelper('rawmarkdown', function(str) {
 
 
 // Automatically link to AKAs, mostly used on method/function/param/option data types.
-Handlebars.registerHelper('type', function(str) {
+Handlebars.registerHelper('type', function (str) {
 	if (!str) { return; }
-	if ( str in _AKAs ) {
+	if (str in _AKAs) {
 		var id = _AKAs[str];
-		return "<a href='#" + id + "'>" + str + "</a>"
+		return '<a href=\'#' + id + '\'>' + str + '</a>';
 	} else {
 		// Should be a built-in type
 		return str;

--- a/src/template.js
+++ b/src/template.js
@@ -11,13 +11,14 @@ let templateDir = __dirname + '/../templates/basic';
 let templates = Object.create(null);
 
 export function setTemplateDir(newDir) {
+    templates = Object.create(null);
 	templateDir = newDir;
 }
 
 export function getTemplate(templateName) {
 	if (!templates[templateName]) {
 		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
-	}
+    }
 	return templates[templateName];
 }
 

--- a/src/template.js
+++ b/src/template.js
@@ -5,10 +5,10 @@ import sander from 'sander';
 import path from 'path';
 import Handlebars from 'handlebars';
 import marked from 'marked';
-export { Handlebars };
+export {Handlebars as engine};
 
 let templateDir = __dirname + '/../templates/basic';
-let templates = Object.create(null)
+let templates = Object.create(null);
 
 export function setTemplateDir(newDir) {
 	templateDir = newDir;
@@ -19,7 +19,7 @@ export function getTemplate(templateName) {
 		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
 	}
 	return templates[templateName];
-};
+}
 
 
 var _AKAs = {};
@@ -30,7 +30,7 @@ export function setAKAs(akas) {
 	_AKAs = akas;
 }
 
-export Handlebars as engine;
+// export Handlebars as engine;
 
 
 /// TODO: Catch all code blocks and check if the contents is a known class, namespace or AKA

--- a/templates/leaflet/constructor.hbs
+++ b/templates/leaflet/constructor.hbs
@@ -1,0 +1,17 @@
+<table><thead>
+	<tr>
+		<th>Constructor</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	{{#each documentables}}
+	<tr id='{{id}}'>
+		<td><code><b>{{name}}</b>(
+		{{~#each params~}}
+			{{#if type}}<nobr>&lt;{{{type type}}}&gt;</nobr> {{/if}}<i>{{name}}</i>
+			{{~#unless @last}}, {{/unless}}{{/each~}}
+		)</nobr></code></td>
+		<td>{{{markdown comments}}}</td>
+	</tr>
+	{{/each}}
+</tbody></table>

--- a/templates/leaflet/destructor.hbs
+++ b/templates/leaflet/destructor.hbs
@@ -1,0 +1,17 @@
+<table><thead>
+	<tr>
+		<th>Destructor</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	{{#each documentables}}
+	<tr id='{{id}}'>
+		<td><code><b>{{name}}</b>(
+		{{~#each params~}}
+			{{#if type}}<nobr>&lt;{{{type type}}}&gt;</nobr> {{/if}}<i>{{name}}</i>
+			{{~#unless @last}}, {{/unless}}{{/each~}}
+		)</nobr></code></td>
+		<td>{{{markdown comments}}}</td>
+	</tr>
+	{{/each}}
+</tbody></table>


### PR DESCRIPTION
- Refactor regexps into "parsers", put more logic and fine-tune some cases for block comments
- Bundle everything with RollupJS
- Add unit tests with Jasmine (woohoooo!!)
- Add linting with eslint (still incomplete)
- Tweaks here and there
- Bump version to 1.5.0

The output of the Leaflet docs is still the same - the only difference is that Leafdoc now retains empty lines inside comment blocks. This was a nuisance that I could only fix by refactoring the whole block parsing mechanism.