### PR TITLE
Fix passing dir to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You will find a `Leafdoc.html` file. Open that file in a web browser, and you'll
 
 ```sh
 npm install leafdoc
-node_modules/.bin/leafdoc -t node_modules/leafdoc/templates/basic -o documentation.html src/*.js
+node_modules/.bin/leafdoc -t node_modules/leafdoc/templates/basic -o documentation.html src
 ```
 
 See [Leafdoc's own documentation](http://leaflet.github.io/Leafdoc/Leafdoc.html) for a reference of available parameters.

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ Leafdoc includes a small command-line utility, useful when running from a consol
 
 🍂example
 
-`leafdoc -t templates/pretty -c '@' --verbose -o documentation.html src/*.js`
+`leafdoc -t templates/pretty -c '@' --verbose -o documentation.html src`
 
 */
 


### PR DESCRIPTION
I tried to make it work with `*`, but no success. Looks like `sander` doesn't support such syntax