### PR TITLE
Replace 'sander' dependency with 'fs'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "handlebars": "^4.0.11",
     "marked": "^0.3.12",
     "minimist": "^1.2.0",
-    "sander": "^0.6.0",
     "unicode-7.0.0": "^0.1.5",
     "xregexp": "^2.0.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ export default [
 //             builtins(),
 //             globals()
         ],
-        external: ['sander', 'path']
+        external: ['fs', 'path']
     },
 
     // CommonJS (for Node) and ES module (for bundlers) build.
@@ -46,7 +46,7 @@ export default [
 //             resolve(), // so Rollup can find `crc32`
 // 			commonjs() // so Rollup can convert `crc32` to an ES module
         ],
-        external: ['sander', 'path']
+        external: ['fs', 'path']
     },
     
     
@@ -65,6 +65,6 @@ export default [
 //             resolve(), // so Rollup can find `crc32`
 // 			commonjs() // so Rollup can convert `crc32` to an ES module
         ],
-        external: ['sander', 'path']
+        external: ['fs', 'path']
     }
 ];

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,11 +15,10 @@ Leafdoc includes a small command-line utility, useful when running from a consol
 */
 
 
-
-var minimist = require('minimist');
-var sander = require('sander');
-var Leafdoc = require('./leafdoc');
+var fs = require("fs");
 var path = require('path');
+var minimist = require('minimist');
+var Leafdoc = require('./leafdoc');
 
 var argv = minimist(process.argv.slice(2), {
 	alias: {
@@ -52,7 +51,7 @@ var doc = new Leafdoc({
 
 argv._.forEach(function (filepath) {
 	try {
-		var stats = sander.statSync(filepath);
+		var stats = fs.lstatSync(filepath);
 
 		if (stats.isFile()) {
 			doc.addFile(filepath, path.extname(filepath) !== '.leafdoc');
@@ -74,7 +73,7 @@ if (argv.json) {
 }
 
 if (argv.output) {
-	sander.writeFileSync(argv.output, out);
+	fs.writeFileSync(argv.output, out);
 } else {
 	console.log(out);
 }

--- a/src/leafdoc.js
+++ b/src/leafdoc.js
@@ -1,5 +1,5 @@
 
-import sander from 'sander';
+import fs from 'fs';
 import path from 'path';
 
 import {getTemplate, setTemplateDir, setAKAs} from './template';
@@ -158,13 +158,13 @@ Leafdoc.prototype.addDir = function (dirname, extensions) {
 		extensions = ['.js', '.leafdoc'];
 	}
 
-	var filenames = sander.readdirSync(dirname);
+	var filenames = fs.readdirSync(dirname);
 
 	for (var i in filenames) {
 		var filename = path.join(dirname, filenames[i]);
 		// Check if dir, recurse if so
 
-		var stats = sander.statSync(filename);
+		var stats = fs.lstatSync(filename);
 		if (stats.isDirectory()) {
 			this.addDir(filename, extensions);
 		} else if (extensions.indexOf(path.extname(filename)) !== -1) {
@@ -182,7 +182,7 @@ Leafdoc.prototype.addDir = function (dirname, extensions) {
 // 🍂method addFile(filename: String, isSource?: Boolean): this
 // Parses the given file using [`addBuffer`](#leafdoc-addbuffer).
 Leafdoc.prototype.addFile = function (filename, isSource) {
-	return this.addBuffer(sander.readFileSync(filename), isSource);
+	return this.addBuffer(fs.readFileSync(filename), isSource);
 };
 
 

--- a/src/template.js
+++ b/src/template.js
@@ -1,7 +1,7 @@
 
 // Minor wrapper over Handlebars
 
-import sander from 'sander';
+import fs from 'fs';
 import path from 'path';
 import Handlebars from 'handlebars';
 import marked from 'marked';
@@ -17,7 +17,7 @@ export function setTemplateDir(newDir) {
 
 export function getTemplate(templateName) {
 	if (!templates[templateName]) {
-		templates[templateName] = Handlebars.compile(sander.readFileSync(templateDir, templateName + '.hbs').toString());
+		templates[templateName] = Handlebars.compile(fs.readFileSync(path.join(templateDir, templateName + '.hbs')).toString());
 	}
 	return templates[templateName];
 }

--- a/test.js
+++ b/test.js
@@ -13,6 +13,6 @@ doc.addDir('src');
 var out = doc.outputStr();
 var json = doc.outputJSON();
 
-var sander = require('sander');
-sander.writeFileSync('Leafdoc.html', out);
-sander.writeFileSync('Leafdoc.json', json);
+var fs = require('fs');
+fs.writeFileSync('Leafdoc.html', out);
+fs.writeFileSync('Leafdoc.json', json);


### PR DESCRIPTION
Sander is a library that has not been updated in years. It depends on `graceful-fs`, that produces [this issue](Leaflet/Leaflet/issues/7021) on some builds.
I've removed the dependency and replaced it with standard `fs` module. This pull closes Leaflet/Leaflet/issues/7021.