### PR TITLE
Fix multilang parser '.mjs' support, __dirname not defined error and update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "xregexp": "^4.3.0"
   },
   "scripts": {
-    "update-markdown-leafdoc": "src/cli.mjs -t templates/markdown src/cli.js src/leafdoc.mjs --verbose -o Leafdoc.md",
-    "update-html-leafdoc": "src/cli.mjs -t templates/basic src/leafdoc.mjs src/cli.js --verbose -o Leafdoc.html",
+    "update-markdown-leafdoc": "src/cli.mjs -t templates/markdown src/cli.mjs src/leafdoc.mjs --verbose -o Leafdoc.md",
+    "update-html-leafdoc": "src/cli.mjs -t templates/basic src/leafdoc.mjs src/cli.mjs --verbose -o Leafdoc.html",
     "prepublish": "npm run update-markdown-leafdoc && npm run update-html-leafdoc",
     "rollup": "rollup -c rollup.config.js",
     "test": "rollup -c rollup.config.js; jasmine",
@@ -50,8 +50,7 @@
       "sourceType": "module"
     },
     "rules": {
-    "prefer-arrow-callback": 0,
-
+      "prefer-arrow-callback": 0,
       "indent": [
         1,
         "tab",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "handlebars": "^4.7.6",
     "markdown-it": "^11.0.0",
     "minimist": "^1.2.5",
-    "multilang-extract-comments": "^0.3.2",
+    "multilang-extract-comments": "^0.3.3",
     "regenerate-unicode-properties": "^8.2.0",
     "xregexp": "^4.3.0"
   },

--- a/src/leafdoc.mjs
+++ b/src/leafdoc.mjs
@@ -260,7 +260,7 @@ export default class Leafdoc {
 
 				let match;
 				// In "param foo, bar", directive is "param" and content is "foo, bar"
-				while (match = regexps.leafDirective.exec(line)) {
+				while (match = regexps.getLeafDirective().exec(line)) {
 					if (match[2]) { match[2] = match[2].trim(); }
 					directives.push([match[1], match[2]]);	// [directive, content]
 					// console.log('directive match: ', match);

--- a/src/parsers/multilang.mjs
+++ b/src/parsers/multilang.mjs
@@ -1,11 +1,18 @@
 
+import path from 'path';
+
 import mec from 'multilang-extract-comments';
 
 // Generic parser, depends on multiline-extract-comments and returns a simplified
 // version of the comments data structure
 
 export default function multilangParser(str, filename) {
-	const mecBlocks = mec(str, {filename: filename || 'leafdoc_tmp.js'});
+	// comment-patterns dependency of mec, doesn't have support for '.mjs' modules,
+	// see https://git.io/JJWUQ
+	if (!filename || path.extname(filename) === '.mjs') {
+		filename = 'leafdoc_tmp.js';
+	}
+	const mecBlocks = mec(str, {filename});
 	const blocks = Object.values(mecBlocks).map(mecBlock => mecBlock.content.trim()).filter(block => block && block !== '');
 
 	return blocks;

--- a/src/parsers/multilang.mjs
+++ b/src/parsers/multilang.mjs
@@ -8,7 +8,7 @@ import mec from 'multilang-extract-comments';
 
 export default function multilangParser(str, filename) {
 	// comment-patterns dependency of mec, doesn't have support for '.mjs' modules,
-	// see https://git.io/JJWUQ
+	// see https://github.com/nknapp/comment-patterns/pull/9
 	if (!filename || path.extname(filename) === '.mjs') {
 		filename = 'leafdoc_tmp.js';
 	}

--- a/src/parsers/multilang.mjs
+++ b/src/parsers/multilang.mjs
@@ -7,12 +7,7 @@ import mec from 'multilang-extract-comments';
 // version of the comments data structure
 
 export default function multilangParser(str, filename) {
-	// comment-patterns dependency of mec, doesn't have support for '.mjs' modules,
-	// see https://github.com/nknapp/comment-patterns/pull/9
-	if (!filename || path.extname(filename) === '.mjs') {
-		filename = 'leafdoc_tmp.js';
-	}
-	const mecBlocks = mec(str, {filename});
+	const mecBlocks = mec(str, {filename: filename || 'leafdoc_tmp.js'});
 	const blocks = Object.values(mecBlocks).map(mecBlock => mecBlock.content.trim()).filter(block => block && block !== '');
 
 	return blocks;

--- a/src/regexps.mjs
+++ b/src/regexps.mjs
@@ -27,11 +27,16 @@ export const leadingLine = xRegExp('^ \\s*/{0,4}\\s{0,1} (?<line> .* )  $', 'nx'
 export const anyLine = xRegExp('^ (?<line> .* ) $', 'nx');
 
 // Parses a 🍂 directive, init'd at redoLeafDirective()
-export let leafDirective = redoLeafDirective('🍂');
+global.leafDirective = redoLeafDirective('🍂');
+
+export function getLeafDirective() {
+	return global.leafDirective;
+} 
 
 // Re-builds the 🍂 directive based on a different leading character
 export function redoLeafDirective(char) {
-	return xRegExp(`  \\s* ${  char  } (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} `, 'gnx');
+	global.leafDirective = xRegExp(`  \\s* ${  char  } (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} `, 'gnx');
+	return global.leafDirective;
 }
 
 // Parses an identifier, allowing only unicode ID_Start and ID_Continue characters

--- a/src/regexps.mjs
+++ b/src/regexps.mjs
@@ -31,8 +31,7 @@ export let leafDirective = redoLeafDirective('🍂');
 
 // Re-builds the 🍂 directive based on a different leading character
 export function redoLeafDirective(char) {
-	leafDirective = xRegExp(`  \\s* ${  char  } (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} `, 'gnx');
-	return leafDirective;
+	return xRegExp(`  \\s* ${  char  } (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} `, 'gnx');
 }
 
 // Parses an identifier, allowing only unicode ID_Start and ID_Continue characters

--- a/src/template.mjs
+++ b/src/template.mjs
@@ -7,7 +7,7 @@ import Handlebars from 'handlebars';
 import MarkdownRenderer from 'markdown-it';
 export {Handlebars as engine};
 
-let templateDir = `${__dirname  }/../templates/basic`;
+let templateDir = path.join(path.resolve(), 'templates', 'basic');
 let templates = Object.create(null);
 
 export function setTemplateDir(newDir) {


### PR DESCRIPTION
- **`src/parsers/multilang.mjs`** I've included a exception when ' .mjs'  files are found by `comment-patterns` library. Also opened [a pull in `comment-patterns`](https://github.com/nknapp/comment-patterns/pull/9) including `.mjs` modules support, but the last change in the project was 2 years ago, so we need to found another way of extract comments or include this type of exceptions to prevent next error happening when I run `npm install`:
```
> leafdoc@1.5.1 update-markdown-leafdoc /home/mondeja/files/code/Leafdoc
> src/cli.mjs -t templates/markdown src/cli.mjs src/leafdoc.mjs --verbose -o Leafdoc.md

/home/mondeja/files/code/Leafdoc/node_modules/comment-patterns/index.js:18
    throw new Error("Cannot find language definition for '" + filename + "'")
          ^

Error: Cannot find language definition for 'src/cli.mjs'
    at langIndex (/home/mondeja/files/code/Leafdoc/node_modules/comment-patterns/index.js:18:11)
    at Function.commentRegex [as regex] (/home/mondeja/files/code/Leafdoc/node_modules/comment-patterns/index.js:50:28)
    at extract (/home/mondeja/files/code/Leafdoc/node_modules/multilang-extract-comments/index.js:31:17)
    at multilangParser (file:///home/mondeja/files/code/Leafdoc/src/parsers/multilang.mjs:8:20)
    at Leafdoc.addStr (file:///home/mondeja/files/code/Leafdoc/src/leafdoc.mjs:228:24)
    at Leafdoc.addBuffer (file:///home/mondeja/files/code/Leafdoc/src/leafdoc.mjs:193:15)
    at Leafdoc.addFile (file:///home/mondeja/files/code/Leafdoc/src/leafdoc.mjs:185:15)
    at file:///home/mondeja/files/code/Leafdoc/src/cli.mjs:57:8
    at Array.forEach (<anonymous>)
    at file:///home/mondeja/files/code/Leafdoc/src/cli.mjs:52:8
```

- **`src/template.mjs`** `__dirname` global constant have been replaced by path resolution from working directory. This prevents next error running `npm install`:
```
file:///home/mondeja/files/code/Leafdoc/src/template.mjs:10
let templateDir = `${__dirname  }/../templates/basic`;

ReferenceError: __dirname is not defined
```
-  **`src/regexps.mjs`** A minor fix to prevent this:
```
> leafdoc@1.5.1 update-markdown-leafdoc /home/mondeja/files/code/Leafdoc
> src/cli.mjs -t templates/markdown src/cli.js src/leafdoc.mjs --verbose -o Leafdoc.md

file:///home/mondeja/files/code/Leafdoc/src/regexps.mjs:34
	leafDirective = xRegExp(`  \\s* ${  char  } (?<directive> \\S+ ) (\\s+ (?<content> [^;\\n]+ )){0,1} `, 'gnx');
	              ^

ReferenceError: Cannot access 'leafDirective' before initialization
``` 